### PR TITLE
Add an API to filter user directory searches by MXID or display name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ typings/
 
 # next.js build output
 .next
+
+# Python packing directories.
+mjolnir.egg-info/

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ spam_checker:
     # this means that spammy messages will appear as empty to users. Default
     # false.
     block_messages: false
+    # Remove users from the user directory search by filtering matrix IDs and
+    # display names by the entries in the user ban list. Default false.
+    block_usernames: false
     # The room IDs of the ban lists to honour. Unlike other parts of Mjolnir,
     # this list cannot be room aliases or permalinks. This server is expected
     # to already be joined to the room - Mjolnir will not automatically join

--- a/synapse_antispam/mjolnir/antispam.py
+++ b/synapse_antispam/mjolnir/antispam.py
@@ -115,6 +115,11 @@ class AntiSpam(object):
     def user_may_publish_room(self, user_id, room_id):
         return True  # allowed
 
+    def check_for_banned_user(self, user_id, display_name):
+        # Check whether the user ID or display name matches any of the banned
+        # patterns.
+        return self.is_user_banned(user_id) or self.is_user_banned(display_name)
+
     @staticmethod
     def parse_config(config):
         return config  # no parsing needed

--- a/synapse_antispam/mjolnir/antispam.py
+++ b/synapse_antispam/mjolnir/antispam.py
@@ -115,10 +115,10 @@ class AntiSpam(object):
     def user_may_publish_room(self, user_id, room_id):
         return True  # allowed
 
-    def check_username_for_spam(self, user_id, display_name):
+    def check_username_for_spam(self, user_profile):
         # Check whether the user ID or display name matches any of the banned
         # patterns.
-        return self.is_user_banned(user_id) or self.is_user_banned(display_name)
+        return self.is_user_banned(user_profile["user_id"]) or self.is_user_banned(user_profile["display_name"])
 
     @staticmethod
     def parse_config(config):

--- a/synapse_antispam/mjolnir/antispam.py
+++ b/synapse_antispam/mjolnir/antispam.py
@@ -115,7 +115,7 @@ class AntiSpam(object):
     def user_may_publish_room(self, user_id, room_id):
         return True  # allowed
 
-    def check_for_banned_user(self, user_id, display_name):
+    def check_username_for_spam(self, user_id, display_name):
         # Check whether the user ID or display name matches any of the banned
         # patterns.
         return self.is_user_banned(user_id) or self.is_user_banned(display_name)

--- a/synapse_antispam/mjolnir/antispam.py
+++ b/synapse_antispam/mjolnir/antispam.py
@@ -24,6 +24,7 @@ class AntiSpam(object):
     def __init__(self, config, api):
         self.block_invites = config.get("block_invites", True)
         self.block_messages = config.get("block_messages", False)
+        self.block_usernames = config.get("block_usernames", False)
         self.list_room_ids = config.get("ban_lists", [])
         self.rooms_to_lists = {}  # type: Dict[str, BanList]
         self.api = api
@@ -106,6 +107,14 @@ class AntiSpam(object):
 
         return True  # allowed (as far as we're concerned)
 
+    def check_username_for_spam(self, user_profile):
+        if not self.block_usernames:
+            return True  # allowed (we aren't blocking based on usernames)
+
+        # Check whether the user ID or display name matches any of the banned
+        # patterns.
+        return self.is_user_banned(user_profile["user_id"]) or self.is_user_banned(user_profile["display_name"])
+
     def user_may_create_room(self, user_id):
         return True  # allowed
 
@@ -114,11 +123,6 @@ class AntiSpam(object):
 
     def user_may_publish_room(self, user_id, room_id):
         return True  # allowed
-
-    def check_username_for_spam(self, user_profile):
-        # Check whether the user ID or display name matches any of the banned
-        # patterns.
-        return self.is_user_banned(user_profile["user_id"]) or self.is_user_banned(user_profile["display_name"])
 
     @staticmethod
     def parse_config(config):


### PR DESCRIPTION
This would depend on matrix-org/synapse#6888 to be functional, it is likely worth taking a quick look at the API design in there first.

As noted in the synapse PR, I don't love the name of the chosen API method. Any suggestions would be appreciated!

I'm unsure if it makes sense to apply the same filtering (`is_user_banned`) over both the MXID and the display name, but it seemed like the simplest change to start with. What are your thoughts on this?

Related to matrix-org/synapse#5648.