### PR TITLE
Add a WordList protection

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -107,6 +107,24 @@ commands:
   additionalPrefixes:
     - "mjolnir_bot"
 
+# Configuration specific to certain toggleable protections
+protections:
+  # Configuration for the wordlist plugin, which can ban users based if they say certain
+  # blocked words shortly after joining.
+  wordlist:
+    # A list of words which should be monitored by the bot.  These will match if any part
+    # of the word is present in the message in any case.  e.g. "poop" also matches
+    # "poOPYHEad".  Additionally, regular expressions can be used.
+    words:
+      - "nigger"
+      - "faggot"
+      - "tranny"
+      - "retard"
+    # How long after a user joins the server should the bot monitor their messages.  After
+    # this time, users can say words from the wordlist without being banned automatically.
+    # Set to zero to disable (users will always be banned if they say a bad word)
+    minutesBeforeTrusting: 20
+
 # Options for monitoring the health of the bot
 health:
   # healthz options. These options are best for use in container environments

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -113,8 +113,8 @@ protections:
   # blocked words shortly after joining.
   wordlist:
     # A list of words which should be monitored by the bot.  These will match if any part
-    # of the word is present in the message in any case.  e.g. "poop" also matches
-    # "poOPYHEad".  Additionally, regular expressions can be used.
+    # of the word is present in the message in any case.  e.g. "hello" also matches
+    # "HEllO".  Additionally, regular expressions can be used.
     words:
       - "CaSe"
       - "InSeNsAtIve"

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -120,6 +120,7 @@ protections:
       - "InSeNsAtIve"
       - "WoRd"
       - "LiSt"
+
     # How long after a user joins the server should the bot monitor their messages.  After
     # this time, users can say words from the wordlist without being banned automatically.
     # Set to zero to disable (users will always be banned if they say a bad word)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -116,10 +116,10 @@ protections:
     # of the word is present in the message in any case.  e.g. "poop" also matches
     # "poOPYHEad".  Additionally, regular expressions can be used.
     words:
-      - "nigger"
-      - "faggot"
-      - "tranny"
-      - "retard"
+      - "CaSe"
+      - "InSeNsAtIve"
+      - "WoRd"
+      - "LiSt"
     # How long after a user joins the server should the bot monitor their messages.  After
     # this time, users can say words from the wordlist without being banned automatically.
     # Set to zero to disable (users will always be banned if they say a bad word)

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,7 +97,7 @@ const defaultConfig: IConfig = {
     },
     protections: {
         wordlist: {
-            words: ["nigger", "faggot", "tranny", "retard"],
+            words: [],
             minutesBeforeTrusting: 20
         }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,12 @@ interface IConfig {
         allowNoPrefix: boolean;
         additionalPrefixes: string[];
     };
+    protections: {
+        wordlist: {
+            words: string[];
+            minutesBeforeTrusting: number;
+        };
+    };
     health: {
         healthz: {
             enabled: boolean;
@@ -88,6 +94,12 @@ const defaultConfig: IConfig = {
     commands: {
         allowNoPrefix: false,
         additionalPrefixes: [],
+    },
+    protections: {
+        wordlist: {
+            words: ["nigger", "faggot", "tranny", "retard"],
+            minutesBeforeTrusting: 20
+        }
     },
     health: {
         healthz: {

--- a/src/protections/WordList.ts
+++ b/src/protections/WordList.ts
@@ -1,0 +1,88 @@
+/*
+Copyright 2019, 2020 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { IProtection } from "./IProtection";
+import { Mjolnir } from "../Mjolnir";
+import { LogLevel, LogService } from "matrix-bot-sdk";
+import { logMessage } from "../LogProxy";
+import config from "../config";
+import { isTrueJoinEvent } from "../utils";
+
+export class WordList implements IProtection {
+
+    private justJoined: { [roomId: string]: { [username: string]: Date} } = {};
+    private badWords: RegExp = new RegExp(/.*(poopyhead).*/i)
+
+    constructor() {
+    }
+
+    public get name(): string {
+        return 'WordList';
+    }
+
+    public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any> {
+        if (!this.justJoined[roomId]) this.justJoined[roomId] = {};
+
+        const content = event['content'] || {};
+
+        // When a new member logs in, store the time they joined.  This will be useful
+        // when we need to check if a message was sent within 20 minutes of joining
+        if (event['type'] === 'm.room.member') {
+            if (isTrueJoinEvent(event)) {
+                const now = new Date();
+                this.justJoined[roomId][event['state_key']] = now;
+                LogService.info("WordList", `${event['state_key']} joined ${roomId} at ${now.toDateString()}`);
+            } else if (content['membership'] == 'leave' || content['membership'] == 'ban') {
+                delete this.justJoined[roomId][event['sender']]
+            }
+
+            return; // stop processing (membership event spam is another problem)
+        }
+
+        if (event['type'] === 'm.room.message') {
+            const message = content['formatted_body'] || content['body'] || null;
+
+            const joinTime = this.justJoined[roomId][event['sender']]
+            if (joinTime) { // Disregard if the user isn't recently joined
+
+                // Check if they did join recently, was it within 20 minutes
+                const now = new Date();
+                if (now.valueOf() - joinTime.valueOf() > 20 * 60 * 1000) {
+                    delete this.justJoined[roomId][event['sender']] // Remove the user
+                    LogService.info("WordList", `${event['sender']} is no longer considered suspect`);
+                    return
+                }
+
+                // Perform the test
+                if (message && this.badWords.test(message)) {
+                    await logMessage(LogLevel.WARN, "WordList", `Banning ${event['sender']} for word list violation in ${roomId}.`);
+                    if (!config.noop) {
+                        await mjolnir.client.banUser(event['sender'], roomId, "Word list violation");
+                    } else {
+                        await logMessage(LogLevel.WARN, "WordList", `Tried to ban ${event['sender']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                    }
+
+                    // Redact the event
+                    if (!config.noop) {
+                        await mjolnir.client.redactEvent(roomId, event['event_id'], "spam");
+                    } else {
+                        await logMessage(LogLevel.WARN, "WordList", `Tried to redact ${event['event_id']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/protections/WordList.ts
+++ b/src/protections/WordList.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2019, 2020 The Matrix.org Foundation C.I.C.
+Copyright 2020 Emi Tatsuo Simpson et al.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,9 +41,9 @@ export class WordList implements IProtection {
     public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any> {
 
         const content = event['content'] || {};
-        const mbt = config.protections.wordlist.minutesBeforeTrusting;
+        const minsBeforeTrusting = config.protections.wordlist.minutesBeforeTrusting;
 
-        if (mbt > 0) {
+        if (minsBeforeTrusting > 0) {
             if (!this.justJoined[roomId]) this.justJoined[roomId] = {};
 
             // When a new member logs in, store the time they joined.  This will be useful
@@ -65,13 +65,13 @@ export class WordList implements IProtection {
             const message = content['formatted_body'] || content['body'] || null;
 
             // Check conditions first
-            if (mbt > 0) {
+            if (minsBeforeTrusting > 0) {
                 const joinTime = this.justJoined[roomId][event['sender']]
                 if (joinTime) { // Disregard if the user isn't recently joined
 
                     // Check if they did join recently, was it within the timeframe
                     const now = new Date();
-                    if (now.valueOf() - joinTime.valueOf() > mbt * 60 * 1000) {
+                    if (now.valueOf() - joinTime.valueOf() > minsBeforeTrusting * 60 * 1000) {
                         delete this.justJoined[roomId][event['sender']] // Remove the user
                         LogService.info("WordList", `${event['sender']} is no longer considered suspect`);
                         return

--- a/src/protections/WordList.ts
+++ b/src/protections/WordList.ts
@@ -29,7 +29,7 @@ export class WordList implements IProtection {
     constructor() {
         // Create a mega-regex from all the tiny baby regexs
         this.badWords = new RegExp(
-            "(" + config.protections.wordlist.words.join(")|(")+ ")",
+            "(" + config.protections.wordlist.words.join(")|(") + ")",
             "i"
         )
     }
@@ -53,7 +53,7 @@ export class WordList implements IProtection {
                     const now = new Date();
                     this.justJoined[roomId][event['state_key']] = now;
                     LogService.info("WordList", `${event['state_key']} joined ${roomId} at ${now.toDateString()}`);
-                } else if (content['membership'] == 'leave' || content['membership'] == 'ban') {
+                } else if (content['membership'] === 'leave' || content['membership'] === 'ban') {
                     delete this.justJoined[roomId][event['sender']]
                 }
 

--- a/src/protections/protections.ts
+++ b/src/protections/protections.ts
@@ -31,7 +31,7 @@ export const PROTECTIONS: PossibleProtections = {
         factory: () => new BasicFlooding(),
     },
     [new WordList().name]: {
-        description: "If a user posts a monitored word within 20 minutes of joining, they " +
+        description: "If a user posts a monitored word a set amount of time after joining, they " +
             "will be banned from that room.  This will not publish the ban to a ban list.",
         factory: () => new WordList(),
     }

--- a/src/protections/protections.ts
+++ b/src/protections/protections.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { FirstMessageIsImage } from "./FirstMessageIsImage";
 import { IProtection } from "./IProtection";
 import { BasicFlooding, MAX_PER_MINUTE } from "./BasicFlooding";
+import { WordList } from "./WordList";
 
 export const PROTECTIONS: PossibleProtections = {
     [new FirstMessageIsImage().name]: {
@@ -28,6 +29,11 @@ export const PROTECTIONS: PossibleProtections = {
         description: "If a user posts more than " + MAX_PER_MINUTE + " messages in 60s they'll be " +
             "banned for spam. This does not publish the ban to any of your ban lists.",
         factory: () => new BasicFlooding(),
+    },
+    [new WordList().name]: {
+        description: "If a user posts a monitored word within 20 minutes of joining, they " +
+            "will be banned from that room.  This will not publish the ban to a ban list.",
+        factory: () => new WordList(),
     }
 };
 


### PR DESCRIPTION
Add a protection for banning users based off of the use of certain blocked words.

Customization allows for modifying the word list in the config, using case-insensitive regexs to detect malicious messages.  Additionally, can be configured to only apply to messages set within a certain time period after a user joins, a feature which is beneficial in environments where certain words may come up naturally in conversation, but are almost always a red flag if used immediately on joining.  This does not add users to a ban list.

A feature like this stands to benefit many room admins.  In my experience, much of room administration is just noticing trolls and banning that quickly.  Many trolls make this blatantly easy by using inflammatory language immediately on joining, to the point that automating it is trivial and likely to have a high accuracy rate.

I'd love to hear your thoughts

```
Signed-off-by: Emi Tatsuo <emi@alchemi.dev>
```