### PR TITLE
Add confirmation for wildcard bans

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -107,6 +107,10 @@ commands:
   additionalPrefixes:
     - "mjolnir_bot"
 
+  # If true, ban commands that use wildcard characters require confirmation with
+  # an extra `--force` argument
+  confirmWildcardBan: true
+
 # Configuration specific to certain toggleable protections
 protections:
   # Configuration for the wordlist plugin, which can ban users based if they say certain

--- a/src/commands/UnbanBanCommand.ts
+++ b/src/commands/UnbanBanCommand.ts
@@ -89,6 +89,12 @@ export async function parseArguments(roomId: string, event: any, mjolnir: Mjolni
     else if (!ruleType) replyMessage = "Please specify the type as either 'user', 'room', or 'server'";
     else if (!entity) replyMessage = "No entity found";
 
+    if (config.commands.confirmWildcardBan && /[*?]/.test(entity)) {
+        if (!parts.includes("--force")) {
+            replyMessage = "Wildcard bans require an additional `--force` argument to confirm";
+        }
+    }
+
     if (replyMessage) {
         const reply = RichReply.createFor(roomId, event, replyMessage, replyMessage);
         reply["msgtype"] = "m.notice";

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,7 @@ interface IConfig {
     commands: {
         allowNoPrefix: boolean;
         additionalPrefixes: string[];
+        confirmWildcardBan: boolean;
     };
     protections: {
         wordlist: {
@@ -94,6 +95,7 @@ const defaultConfig: IConfig = {
     commands: {
         allowNoPrefix: false,
         additionalPrefixes: [],
+        confirmWildcardBan: true,
     },
     protections: {
         wordlist: {


### PR DESCRIPTION
This adds a default enabled option to require confirmation for wildcard bans
(e.g. those containing `*` or `?`). Users will need to also add `--force` for
the commands to be accepted.