### PR TITLE
[WIP] Defining a DSL to send rules to the spam checker

### DIFF
--- a/dsl.ts
+++ b/dsl.ts
@@ -1,7 +1,8 @@
 /**
- * A antispam rule.
+ * An elementary antispam rule, used to match a single value against a
+ * regexp (or an equivalent but more optimized substring search).
  * 
- * The rule will **reject** (i.e. consider as spam) if either `literals`
+ * The rule will **reject** (i.e. consider as spam) if either `substrings`
  * or `regexp` matches the value.
  *
  * The rule will **accept** (i.e. let pass) otherwise.
@@ -9,7 +10,7 @@
  * Note that this rule is typically obtained by or-ing several rules
  * on the ruleserver side.
  */
-type Rule = {
+type Matcher = {
     /// The date of the latest update.
     ///
     /// Used to avoid needlessly recompiling rules on the spamchecker side,
@@ -29,96 +30,89 @@ type Rule = {
 };
 
 /**
- * All the sources of information available to the antispam
- * when running `user_may_invite`.
+ * An antispam rule for `user_may_invite`.
  */
 type InviteRules = {
     /// The full user id of the inviter.
-    inviter_user_id: Rule,
+    inviter_user_id: Matcher,
 
     /// The full user id if the potential new room member.
-    new_member_user_id: Rule,
+    new_member_user_id: Matcher,
 
     /// The room id.
-    room_id: Rule,
+    room_id: Matcher,
 };
 
 /**
- * All the sources of information available to the antispam
- * when running `user_may_create_room`.
+ * An antispam rule for `user_may_create_room`.
  */
 type RoomCreateRules = {
     /// The full user id of the room creator.
-    user_id: Rule,
+    user_id: Matcher,
 };
 
 /**
- * All the sources of information available to the antispam
- * when running `user_may_create_room_alias`.
+ * An antispam rule for `user_may_create_room_alias`.
  */
 type AliasCreateRules = {
     /// The full user id of the alias creator.
-    user_id: Rule,
+    user_id: Matcher,
 
     /// The human-readable alias.
-    desired_alias: Rule,
+    desired_alias: Matcher,
 };
 
 /**
- * All the sources of information available to the antispam
- * when running `user_may_publish_room`.
+ * An antispam rule for `user_may_publish_room`.
  */
 type PublishRoomRules = {
     /// The full user id of the publisher.
-    publisher_user_id: Rule,
+    publisher_user_id: Matcher,
 
     /// The room id.
-    room_id: Rule,
+    room_id: Matcher,
 };
 
 /**
- * All the sources of information available to the antispam
- * when running `check_username_for_spam`.
+ * An antispam rule for `check_username_for_spam`.
  */
 type CheckUsernameForSpamRules = {
     /// The full user id of the user.
-    user_id: Rule,
+    user_id: Matcher,
 
     /// The display name of the user.
-    display_name: Rule,
+    display_name: Matcher,
 
     /// The URL towards the avatar of the user.
-    avatar_url: Rule,
+    avatar_url: Matcher,
 };
 
 /**
- * All the sources of information available to the antispam
- * when running `check_registration_for_spam`.
+ * An antispam rule for `check_registration_for_spam`.
  */
 type CheckRegistrationForSpamRules = {
     /// The username, if available.
-    maybe_user_name: Rule,
+    maybe_user_name: Matcher,
 
     /// The email used for registration, if available.
-    maybe_email: Rule,
+    maybe_email: Matcher,
 
     /// The list of user agents used during registration (possibly empty).
     /// A registration will be considered spammy if any of the
     /// user agents matches the rule.
-    user_agent_list: Rule,
+    user_agent: Matcher,
 
     /// The list of IPs used during registration (possibly empty).
     /// A registration will be considered spammy if any of the
     /// IPs matches the rule.
-    ip_list: Rule,
+    ip: Matcher,
 
     /// The auth provider, if available, e.g. "oidc", "saml", ...
-    maybe_auth_provider_id: Rule
+    maybe_auth_provider_id: Matcher
 };
 
 /**
- * All the sources of information available to the antispam
- * when running `check_event_for_spam`.
+ * An antispam rule for `check_event_for_spam`.
  */
 type CheckEventForSpamRules = {
     /// A path of fields within the event object.
@@ -127,31 +121,37 @@ type CheckEventForSpamRules = {
     ///
     /// If any of the fields is not present, the rule will **not** match (i.e. the
     /// message will not be considered spam).
-    event: { [path: string]: Rule },
+    event: { [path: string]: Matcher },
 };
 
 /**
- * A batch of rules.
+ * The complete list of rules for an instance of the spam-checker.
  */
 type RuleSet = {
+    /// If the rules match, user cannot invite other user.
     user_may_invite: InviteRules,
+
+    /// If the rules match, user cannot create room.
     user_may_create_room: RoomCreateRules,
+
+    /// If the rules match, user cannot create an alias for the room.
     user_may_create_room_alias: AliasCreateRules,
+
+    /// If the rules match, user cannot make the room public.
     user_may_publish_room: PublishRoomRules,
+
+    /// If the rules match, register user and immediately shadowban them.
+    check_registration_for_spam_shadowban: CheckRegistrationForSpamRules,
+
+    /// If the rules of `check_registration_for_spam_shadowban` do NOT
+    /// match but these rules match, deny registration.
+    check_registration_for_spam_deny: CheckRegistrationForSpamRules,
+
+    /// If the rules match, deny registration, regardless of
+    /// the result of `check_registration_for_spam_shadowban`
+    /// and `check_registration_for_spam_deny`.
     check_username_for_spam: CheckUsernameForSpamRules,
-    check_registration_for_spam: CheckRegistrationForSpamRules,
+
+    /// If the rules match, event will bounce.
     check_event_for_spam: CheckEventForSpamRules,
-};
-
-/**
- * An update sent by the rule server to the antispam.
- */
-type Update = {
-    /// A batch of rules to remove.
-    ///
-    /// Use special value `"*"` to clear out all rules.
-    remove: RuleSet | "*",
-
-    /// A batch of rules to add.
-    add: RuleSet,
 };

--- a/dsl.ts
+++ b/dsl.ts
@@ -108,19 +108,26 @@ enum CheckRegistrationForSpamContext {
  * All the sources of information available to the antispam
  * when running `check_event_for_spam`.
  */
-enum CheckEventForSpamContext {
+type CheckEventForSpamContext =
     /// The full user id of the sender.
-    sender_user_id,
+    "sender_user_id"
 
     /// The domain of the sender.
-    sender_domain,
+    | "sender_domain"
 
     /// The room id.
-    room_id,
+    | "room_id"
 
-    /// If the message contains a text, the content of the text.
-    maybe_message_text,
-};
+    | {
+        /// A path of fields within the event object.
+        ///
+        /// e.g. `["content", "formatted_body"]` will return `event.content.formatted_body`.
+        ///
+        /// If any of the fields is not present, the rule will **not** match (i.e. the
+        /// message will not be considered spam).
+        path: string[]
+    }
+;
 
 /**
  * A rule served by the Rule Server.

--- a/dsl.ts
+++ b/dsl.ts
@@ -1,157 +1,184 @@
 /**
- * An elementary antispam rule, used to match a single value against a
- * regexp (or an equivalent but more optimized substring search).
+ * A format for sending spam-checker rules from a rule server to
+ * a synapse spam-checker.
  * 
- * The rule will **reject** (i.e. consider as spam) if either `substrings`
- * or `regexp` matches the value.
+ * The intended use is that the spam-checker will regularly
+ *
+ * GET https://example.org/mjolnir/rules?since=timestamp
+ *
+ * And receive an update of the rules since timestamp.
+ */
+
+interface Literal {}
+interface Regexp {}
+
+/// A list of additions/removal.
+///
+/// Additions are resolved *after* removals.
+///
+/// Type parameter `T` is used as a phantom type to distinguish between
+/// literal strings (`Literal`) or regexp strings (`Regexp`).
+type Patch<T> = {
+    /// Remove some or all items.
+    remove?: "clear" | string[],
+
+    /// Add items.
+    add?: string[],
+}
+
+/**
+ * An update to an elementary spam rule, attempting to match a single value
+ * (e.g. a user_id) against a number of regexps.
+ * 
+ * The rule will **reject** (i.e. consider as spam) if the value **contains**
+ * any of the regexps or literals.
  *
  * The rule will **accept** (i.e. let pass) otherwise.
- *
- * Note that this rule is typically obtained by or-ing several rules
- * on the ruleserver side.
  */
-type Matcher = {
-    /// The date of the latest update.
-    ///
-    /// Used to avoid needlessly recompiling rules on the spamchecker side,
-    /// as this can be long and memory-expensive.
-    latest_update: Date,
+type Update = {
+        /// Any number of literals to add/remove.
+        ///
+        /// Whenever possible, prefer literals to regexps, as they are both
+        /// more faster and more memory-efficient.
+        literals?: Patch<Literal>,
 
-    /// Literal values.
-    ///
-    /// When reasonable, prefer one or several literal values to a regexp,
-    /// as they can be compiled into a faster and more memory-efficient
-    /// FSM than a general regexp.
-    substrings: string[],
-
-    /// A single Python regexp (typically obtained by or-ing numerous regexps),
-    /// as specced by https://docs.python.org/3/library/re.html
-    regexp: string | null,
-};
+        /// Any number of regexps to add/remove.
+        ///
+        /// The regexps will be or-ed and compiled spamcheck-side.
+        ///
+        /// These regexps MUST follow the specs of https://docs.python.org/3/library/re.html .
+        regexps?: Patch<Regexp>,
+    };
 
 /**
  * An antispam rule for `user_may_invite`.
  */
-type InviteRules = {
+type InviteUpdates = {
     /// The full user id of the inviter.
-    inviter_user_id: Matcher,
+    inviter_user_id: Update,
 
     /// The full user id if the potential new room member.
-    new_member_user_id: Matcher,
+    new_member_user_id: Update,
 
     /// The room id.
-    room_id: Matcher,
+    room_id: Update,
 };
 
 /**
  * An antispam rule for `user_may_create_room`.
  */
-type RoomCreateRules = {
+type RoomCreateUpdates = {
     /// The full user id of the room creator.
-    user_id: Matcher,
+    user_id: Update,
 };
 
 /**
  * An antispam rule for `user_may_create_room_alias`.
  */
-type AliasCreateRules = {
+type AliasCreateUpdates = {
     /// The full user id of the alias creator.
-    user_id: Matcher,
+    user_id: Update,
 
     /// The human-readable alias.
-    desired_alias: Matcher,
+    desired_alias: Update,
 };
 
 /**
  * An antispam rule for `user_may_publish_room`.
  */
-type PublishRoomRules = {
+type PublishRoomUpdates = {
     /// The full user id of the publisher.
-    publisher_user_id: Matcher,
+    publisher_user_id: Update,
 
     /// The room id.
-    room_id: Matcher,
+    room_id: Update,
 };
 
 /**
  * An antispam rule for `check_username_for_spam`.
  */
-type CheckUsernameForSpamRules = {
+type CheckUsernameForSpamUpdates = {
     /// The full user id of the user.
-    user_id: Matcher,
+    user_id: Update,
 
     /// The display name of the user.
-    display_name: Matcher,
+    display_name: Update,
 
     /// The URL towards the avatar of the user.
-    avatar_url: Matcher,
+    avatar_url: Update,
 };
 
 /**
  * An antispam rule for `check_registration_for_spam`.
  */
-type CheckRegistrationForSpamRules = {
+type CheckRegistrationForSpamUpdates = {
     /// The username, if available.
-    maybe_user_name: Matcher,
+    maybe_user_name: Update,
 
     /// The email used for registration, if available.
-    maybe_email: Matcher,
+    maybe_email: Update,
 
     /// The list of user agents used during registration (possibly empty).
     /// A registration will be considered spammy if any of the
     /// user agents matches the rule.
-    user_agent: Matcher,
+    user_agent: Update,
 
     /// The list of IPs used during registration (possibly empty).
     /// A registration will be considered spammy if any of the
     /// IPs matches the rule.
-    ip: Matcher,
+    ip: Update,
 
     /// The auth provider, if available, e.g. "oidc", "saml", ...
-    maybe_auth_provider_id: Matcher
+    maybe_auth_provider_id: Update
 };
 
 /**
  * An antispam rule for `check_event_for_spam`.
  */
-type CheckEventForSpamRules = {
+type CheckEventForSpamUpdates = {
     /// A path of fields within the event object.
     ///
     /// e.g. `"content.formatted_body"` will return `event.content.formatted_body`.
     ///
     /// If any of the fields is not present, the rule will **not** match (i.e. the
     /// message will not be considered spam).
-    event: { [path: string]: Matcher },
+    event: { [path: string]: Update },
 };
 
 /**
  * The complete list of rules for an instance of the spam-checker.
  */
-type RuleSet = {
+type GlobalUpdate = {
     /// If the rules match, user cannot invite other user.
-    user_may_invite: InviteRules,
+    user_may_invite?: InviteUpdates,
 
     /// If the rules match, user cannot create room.
-    user_may_create_room: RoomCreateRules,
+    user_may_create_room?: RoomCreateUpdates,
 
     /// If the rules match, user cannot create an alias for the room.
-    user_may_create_room_alias: AliasCreateRules,
+    user_may_create_room_alias?: AliasCreateUpdates,
 
     /// If the rules match, user cannot make the room public.
-    user_may_publish_room: PublishRoomRules,
+    user_may_publish_room?: PublishRoomUpdates,
 
     /// If the rules match, register user and immediately shadowban them.
-    check_registration_for_spam_shadowban: CheckRegistrationForSpamRules,
+    check_registration_for_spam_shadowban?: CheckRegistrationForSpamUpdates,
 
     /// If the rules of `check_registration_for_spam_shadowban` do NOT
     /// match but these rules match, deny registration.
-    check_registration_for_spam_deny: CheckRegistrationForSpamRules,
+    check_registration_for_spam_deny?: CheckRegistrationForSpamUpdates,
 
     /// If the rules match, deny registration, regardless of
     /// the result of `check_registration_for_spam_shadowban`
     /// and `check_registration_for_spam_deny`.
-    check_username_for_spam: CheckUsernameForSpamRules,
+    check_username_for_spam?: CheckUsernameForSpamUpdates,
 
     /// If the rules match, event will bounce.
-    check_event_for_spam: CheckEventForSpamRules,
+    check_event_for_spam?: CheckEventForSpamUpdates,
+
+    /// The instant of the latest update, in milliseconds since the Unix epoch.
+    ///
+    /// This value is meant to be passed as argument when requesting
+    /// more recent update.
+    latest_update_ts: number,
 };

--- a/dsl.ts
+++ b/dsl.ts
@@ -1,0 +1,156 @@
+/**
+ * All the sources of information available to the antispam
+ * when running `user_may_invite`.
+ */
+enum InviteContext {
+    /// The full user id of the inviter.
+    inviter_user_id,
+
+    /// The domain of the inviter.
+    inviter_user_domain,
+
+    /// The full user id if the potential new room member.
+    new_member_user_id,
+
+    /// The domain of the potential new room member.
+    new_member_user_domain,
+
+    /// The room id.
+    room_id,
+};
+
+/**
+ * All the sources of information available to the antispam
+ * when running `user_may_create_room`.
+ */
+enum RoomCreateContext {
+    /// The full user id of the room creator.
+    user_id,
+
+    /// The domain of the room creator.
+    user_domain,
+};
+
+/**
+ * All the sources of information available to the antispam
+ * when running `user_may_create_room_alias`.
+ */
+enum AliasCreateContext {
+    /// The full user id of the alias creator.
+    user_id,
+
+    /// The domain of the alias creator.
+    user_domain,
+
+    /// The human-readable alias.
+    desired_alias,
+};
+
+/**
+ * All the sources of information available to the antispam
+ * when running `user_may_publish_room`.
+ */
+enum PublishRoomContext {
+    /// The full user id of the publisher.
+    publisher_user_id,
+
+    /// The domain of the publisher.
+    publisher_domain,
+
+    /// The room id.
+    room_id,
+};
+
+/**
+ * All the sources of information available to the antispam
+ * when running `check_username_for_spam`.
+ */
+enum CheckUsernameForSpamContext {
+    /// The full user id of the user.
+    user_id,
+
+    /// The domain of the user.
+    user_domain,
+
+    /// The display name of the user.
+    display_name,
+
+    /// The URL towards the avatar of the user.
+    avatar_url,
+};
+
+/**
+ * All the sources of information available to the antispam
+ * when running `check_registration_for_spam`.
+ */
+enum CheckRegistrationForSpamContext {
+    /// The username, if available.
+    maybe_user_name,
+
+    /// The email used for registration, if available.
+    maybe_email,
+
+    /// The list of user agents used during registration (possibly empty).
+    /// A registration will be considered spammy if any of the
+    /// user agents matches the regexp.
+    user_agent_list,
+
+    /// The list of IPs used during registration (possibly empty).
+    /// A registration will be considered spammy if any of the
+    /// IPs matches the regexp.
+    ip_list,
+
+    /// The auth provider, if available, e.g. "oidc", "saml", ...
+    maybe_auth_provider_id
+};
+
+/**
+ * All the sources of information available to the antispam
+ * when running `check_event_for_spam`.
+ */
+enum CheckEventForSpamContext {
+    /// The full user id of the sender.
+    sender_user_id,
+
+    /// The domain of the sender.
+    sender_domain,
+
+    /// The room id.
+    room_id,
+
+    /// If the message contains a text, the content of the text.
+    maybe_message_text,
+};
+
+/**
+ * A rule served by the Rule Server.
+ * 
+ * `T` is one of `InviteContext`, `RoomCreateContext`, ...
+ * 
+ * The rule will **reject** (i.e. consider as spam) if `matcher` matches `value`.
+ * The rule will **accept** (i.e. let pass) otherwise.
+ */
+type Rule<T> = {
+    /// The value to match.
+    value: T,
+
+    /// The criteria to decide whether `value` is spam.
+    matcher: Matcher,
+};
+
+/**
+ * A manner of matching strings.
+ *
+ * When possible, prefer `literal` as it is faster and more memory-efficient
+ * than `regexp`.
+ */
+type Matcher =
+    {
+        /// The Python regexp against which to match a string value, as specced
+        /// by https://docs.python.org/3/library/re.html
+        regexp: string
+    }
+  | {
+        /// A literal string against which to match a string value.
+        literal: string
+    };

--- a/dsl.ts
+++ b/dsl.ts
@@ -127,7 +127,24 @@ type CheckEventForSpamContext =
         /// message will not be considered spam).
         path: string[]
     }
-;
+    ;
+
+/**
+ * A manner of matching strings.
+ *
+ * When possible, prefer `literal` as it is faster and more memory-efficient
+ * than `regexp`.
+ */
+type Matcher =
+    {
+        /// The Python regexp against which to match a string value, as specced
+        /// by https://docs.python.org/3/library/re.html
+        regexp: string
+    }
+    | {
+        /// A literal string against which to match a string value.
+        literal: string
+    };
 
 /**
  * A rule served by the Rule Server.
@@ -146,18 +163,27 @@ type Rule<T> = {
 };
 
 /**
- * A manner of matching strings.
- *
- * When possible, prefer `literal` as it is faster and more memory-efficient
- * than `regexp`.
+ * A batch of rules.
  */
-type Matcher =
-    {
-        /// The Python regexp against which to match a string value, as specced
-        /// by https://docs.python.org/3/library/re.html
-        regexp: string
-    }
-  | {
-        /// A literal string against which to match a string value.
-        literal: string
-    };
+type RuleSet = {
+    user_may_invite: Rule<InviteContext>[],
+    user_may_create_room: Rule<RoomCreateContext>[],
+    user_may_create_room_alias: Rule<AliasCreateContext>[],
+    user_may_publish_room: Rule<PublishRoomContext>[],
+    check_username_for_spam: Rule<CheckUsernameForSpamContext>[],
+    check_registration_for_spam: Rule<CheckRegistrationForSpamContext>[],
+    check_event_for_spam: Rule<CheckEventForSpamContext>[],
+};
+
+/**
+ * An update sent by the rule server to the antispam.
+ */
+type Update = {
+    /// A batch of rules to remove.
+    ///
+    /// Use special value `"*"` to clear out all rules.
+    remove: RuleSet | "*",
+
+    /// A batch of rules to add.
+    add: RuleSet,
+};


### PR DESCRIPTION
First draft of a DSL that we could use to send rules to the spam checker.

This should provide the same expressive power as the current version of https://github.com/matrix-org/mjolnir/pull/78 but without the need to send trusted Python over the wire. If that's satisfying, the next step will be to rewrite the spamchecker to accept these messages (possibly on its own repo, TBD).

