### PR TITLE
catch errors and set non-zero exit code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,4 +117,7 @@ if (config.health.healthz.enabled) {
 
     const bot = new Mjolnir(client, protectedRooms, banLists);
     await bot.start();
-})();
+})().catch(err => {
+    logMessage(LogLevel.ERROR, "index", err);
+    process.exit(1);
+});


### PR DESCRIPTION
Hey there,

I am currently in progress of creating a package/module of mjolnir for NixOS. While reviewing my PR we observed, that mjolnir does not set a non-zero exit code when encountering an error.

For example, when connecting to a not-yet-ready instance of pantalaimon or when connecting to an EMS hosted matrix server with missing consent: https://github.com/NixOS/nixpkgs/pull/123896#discussion_r651041787

e.g. for the missing consent case:
```
Jun 14 15:14:45 kif systemd[1]: Started mjolnir - a moderation tool for Matrix.
Jun 14 15:14:45 kif mjolnir[22947]: Mon, 14 Jun 2021 15:14:45 GMT [INFO] [index] Starting bot...
Jun 14 15:14:46 kif mjolnir[22947]: Mon, 14 Jun 2021 15:14:46 GMT [INFO] [index] Resolving protected rooms...
Jun 14 15:14:46 kif mjolnir[22947]: Mon, 14 Jun 2021 15:14:46 GMT [INFO] [index] Resolving management room...
Jun 14 15:14:47 kif mjolnir[22947]: Mon, 14 Jun 2021 15:14:47 GMT [ERROR] [MatrixHttpClient (REQ-4)] {
Jun 14 15:14:47 kif mjolnir[22947]:   consent_uri: 'https://xxx.ems.host/_matrix/consent?u=xxx&h=xxx',
Jun 14 15:14:47 kif mjolnir[22947]:   errcode: 'M_CONSENT_NOT_GIVEN',
Jun 14 15:14:47 kif mjolnir[22947]:   error: 'To continue using this homeserver you must review and agree to our terms and conditions at https://xxx.ems.host/_matrix/consent?u=xxx&h=xxx.'
Jun 14 15:14:47 kif mjolnir[22947]: }
Jun 14 15:14:47 kif mjolnir[22947]: (node:22947) UnhandledPromiseRejectionWarning: #<IncomingMessage>
Jun 14 15:14:47 kif mjolnir[22947]: (node:22947) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
Jun 14 15:14:47 kif mjolnir[22947]: (node:22947) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
Jun 14 15:14:47 kif systemd[1]: mjolnir.service: Succeeded.
Jun 14 15:14:47 kif systemd[1]: mjolnir.service: Consumed 495ms CPU time, received 3.1K IP traffic, sent 1.9K IP traffic.

```

I've added a catch to the main async function which catches these unhandled promise rejections and sets a non-zero exit code.