### PR TITLE
Gnuxie/change ban redact order

### DIFF
--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -595,10 +595,10 @@ export class Mjolnir {
                 return;
             } else if (event['type'] === "m.room.member") {
                 // Only apply bans in the room we're looking at.
-                const errors = await applyUserBans(this.banLists, [roomId], this);
-                // do we need room scoped redaction here? yes...
-                // I want to get an inital review before i check this bit.
-                await this.printActionResult(errors);
+                const banErrors = await applyUserBans(this.banLists, [roomId], this);
+                const redactionErrors = await this.processRedactionQueue(roomId);
+                await this.printActionResult(banErrors);
+                await this.printActionResult(redactionErrors);
             }
         }
     }
@@ -674,7 +674,7 @@ export class Mjolnir {
         this.eventRedactionQueue.add(new RedactUserInRoom(userId, roomId));
     }
 
-    public async processRedactionQueue() {
-        return await this.eventRedactionQueue.process(this.client);
+    public async processRedactionQueue(roomId?: string) {
+        return await this.eventRedactionQueue.process(this.client, roomId);
     }
 }

--- a/src/actions/ApplyBan.ts
+++ b/src/actions/ApplyBan.ts
@@ -21,7 +21,6 @@ import config from "../config";
 import { logMessage } from "../LogProxy";
 import { LogLevel } from "matrix-bot-sdk";
 import { ERROR_KIND_FATAL, ERROR_KIND_PERMISSION } from "../ErrorCache";
-import { redactUserMessagesIn } from "../utils";
 
 /**
  * Applies the member bans represented by the ban lists to the provided rooms, returning the
@@ -69,7 +68,7 @@ export async function applyUserBans(lists: BanList[], roomIds: string[], mjolnir
                             if (!config.noop) {
                                 await mjolnir.client.banUser(member.userId, roomId, userRule.reason);
                                 if (mjolnir.automaticRedactGlobs.find(g => g.test(userRule.reason.toLowerCase()))) {
-                                    await redactUserMessagesIn(mjolnir.client, member.userId, [roomId]);
+                                    mjolnir.queueRedactUserMessagesIn(member.userId, roomId);
                                 }
                             } else {
                                 await logMessage(LogLevel.WARN, "ApplyBan", `Tried to ban ${member.userId} in ${roomId} but Mjolnir is running in no-op mode`, roomId);

--- a/src/protections/BasicFlooding.ts
+++ b/src/protections/BasicFlooding.ts
@@ -65,7 +65,7 @@ export class BasicFlooding implements IProtection {
             }
 
             if (this.recentlyBanned.includes(event['sender'])) return; // already handled (will be redacted)
-            mjolnir.redactionHandler.addUser(event['sender']);
+            mjolnir.unlistedUserRedactionHandler.addUser(event['sender']);
             this.recentlyBanned.push(event['sender']); // flag to reduce spam
 
             // Redact all the things the user said too

--- a/src/protections/FirstMessageIsImage.ts
+++ b/src/protections/FirstMessageIsImage.ts
@@ -59,7 +59,7 @@ export class FirstMessageIsImage implements IProtection {
                 }
 
                 if (this.recentlyBanned.includes(event['sender'])) return; // already handled (will be redacted)
-                mjolnir.redactionHandler.addUser(event['sender']);
+                mjolnir.unlistedUserRedactionHandler.addUser(event['sender']);
                 this.recentlyBanned.push(event['sender']); // flag to reduce spam
 
                 // Redact the event

--- a/src/queues/AutomaticRedactionQueue.ts
+++ b/src/queues/AutomaticRedactionQueue.ts
@@ -13,7 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+//// NOTE: This is a queue of users whose events should be redacted
+////////// Not a queue of events to be redacted.
+////////// This is also unrelated to the AutomaticRedactionReasons. 
+////////// It is as of writing only used by the flood/spam protections.
 import { extractRequestError, LogLevel, LogService, MatrixClient, Permalinks } from "matrix-bot-sdk";
 import { logMessage } from "../LogProxy";
 import config from "../config";

--- a/src/queues/EventRedactionQueue.ts
+++ b/src/queues/EventRedactionQueue.ts
@@ -1,0 +1,97 @@
+/*
+Copyright 2019-2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+//// NOTE: This is a queue for events so that other protections can happen first (bans and ACL)
+
+import { LogLevel, MatrixClient } from "matrix-bot-sdk"
+import { ERROR_KIND_FATAL } from "../ErrorCache";
+import { logMessage } from "../LogProxy";
+import { RoomUpdateError } from "../models/RoomUpdateError";
+import { redactUserMessagesIn } from "../utils";
+
+export interface QueuedRedaction {
+    redact(client: MatrixClient): Promise<any>
+    redactionEqual(redaction: QueuedRedaction): boolean
+    report(e): RoomUpdateError
+}
+
+export class RedactUserInRoom implements QueuedRedaction {
+    userId: string;
+    roomId: string;
+
+    constructor(userId: string, roomId: string) {
+        this.userId = userId;
+        this.roomId = roomId;
+    }
+
+    public async redact(client: MatrixClient) {
+        await logMessage(LogLevel.DEBUG, "Mjolnir", `Redacting events from ${this.userId} in room ${this.roomId}.`);
+        await redactUserMessagesIn(client, this.userId, [this.roomId]);
+    }
+
+    public redactionEqual(redaction: QueuedRedaction): boolean {
+        if (redaction instanceof RedactUserInRoom) {
+            return redaction.userId === this.userId && redaction.roomId === this.roomId; 
+        } else {
+            return false;
+        }
+    }
+
+    public report(e): RoomUpdateError {
+        const message = e.message || (e.body ? e.body.error : '<no message>');
+        return {
+            roomId: this.roomId,
+            errorMessage: message,
+            errorKind: ERROR_KIND_FATAL,
+        };
+    }
+}
+
+export class EventRedactionQueue {
+    private toRedact: Array<QueuedRedaction> = new Array<QueuedRedaction>();
+
+    public has(redaction: QueuedRedaction) {
+        return this.toRedact.find(r => r.redactionEqual(redaction));
+    }
+
+    public add(redaction: QueuedRedaction) {
+        if (this.has(redaction)) {
+            return;
+        } else {
+            this.toRedact.push(redaction);
+        }
+    }
+
+    public delete(redaction: QueuedRedaction) {
+        this.toRedact = this.toRedact.filter(r => r.redactionEqual(redaction));
+    }
+
+    public async process(client: MatrixClient): Promise<RoomUpdateError[]> {
+        const errors: RoomUpdateError[]= [];
+        // need to change this so it pops the array until empty
+        // otherwise this will be cringe.
+        for (const redaction of this.toRedact) {
+            try {
+                await redaction.redact(client);
+            } catch (e) {
+                errors.push(redaction.report(e));
+            } finally {
+                // FIXME: Need to figure out in which circumstances we want to retry.
+                this.delete(redaction);
+            }
+        }
+        return errors;
+    } 
+}

--- a/src/queues/UnlistedUserRedactionQueue.ts
+++ b/src/queues/UnlistedUserRedactionQueue.ts
@@ -18,8 +18,12 @@ import { logMessage } from "../LogProxy";
 import config from "../config";
 
 /**
- * This is used to redact new events from users who are not banned from a watched list, but have been flagged
+ * This class is a queue of users who have been flagged
  * for redaction by the flooding or image protection.
+ * Specifically any new events sent by a queued user will be redacted.
+ * This does not handle previously sent events, for that see the EventRedactionQueue.
+ * These users are not listed as banned in any watch list and so may continue
+ * to view a room until a moderator can investigate.
  */
 export class UnlistedUserRedactionQueue {
     private usersToRedact: Set<string> = new Set<string>();

--- a/src/queues/UnlistedUserRedactionQueue.ts
+++ b/src/queues/UnlistedUserRedactionQueue.ts
@@ -18,10 +18,9 @@ import { logMessage } from "../LogProxy";
 import config from "../config";
 
 /**
- * This class is a queue of users who have been flagged
- * for redaction by the flooding or image protection.
+ * A queue of users who have been flagged for redaction typically by the flooding or image protection.
  * Specifically any new events sent by a queued user will be redacted.
- * This does not handle previously sent events, for that see the EventRedactionQueue.
+ * This does not handle previously sent events, for that see the `EventRedactionQueue`.
  * These users are not listed as banned in any watch list and so may continue
  * to view a room until a moderator can investigate.
  */

--- a/src/queues/UnlistedUserRedactionQueue.ts
+++ b/src/queues/UnlistedUserRedactionQueue.ts
@@ -13,15 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-//// NOTE: This is a queue of users whose events should be redacted
-////////// Not a queue of events to be redacted.
-////////// This is also unrelated to the AutomaticRedactionReasons. 
-////////// It is as of writing only used by the flood/spam protections.
 import { extractRequestError, LogLevel, LogService, MatrixClient, Permalinks } from "matrix-bot-sdk";
 import { logMessage } from "../LogProxy";
 import config from "../config";
 
-export class AutomaticRedactionQueue {
+/**
+ * This is used to redact new events from users who are not banned from a watched list, but have been flagged
+ * for redaction by the flooding or image protection.
+ */
+export class UnlistedUserRedactionQueue {
     private usersToRedact: Set<string> = new Set<string>();
 
     constructor() {


### PR DESCRIPTION
I have added a queue to change the order of events when syncing bans for a room. In the situation that a user is banned for a reason that requires events to be redacted, these redactions will now happen after the ban has been applied to every protected room. 