### PR TITLE
Provide notice showing how a BanList has changed after updating.

### DIFF
--- a/src/models/BanList.ts
+++ b/src/models/BanList.ts
@@ -35,15 +35,86 @@ export function ruleTypeToStable(rule: string, unstable = true): string|null {
     return null;
 }
 
+export enum ChangeType {
+    Added    = "ADDED",
+    Removed  = "REMOVED",
+    Modified = "MODIFIED"
+}
+
+export interface ListRuleChange {
+    readonly changeType: ChangeType,
+    /**
+     * State event that caused the change.
+     * If the rule was redacted, this will be the redacted version of the event.
+     */
+    readonly event: any,
+    /**
+     * The sender that caused the change.
+     * The original event sender unless the change is because `event` was redacted. When the change is `event` being redacted
+     * this will be the user who caused the redaction.
+     */
+    readonly sender: string,
+    /**
+     * The current rule represented by the event.
+     * If the rule has been removed, then this will show what the rule was.
+     */
+    readonly rule: ListRule,
+    /**
+     * The previous state that has been changed. Only (and always) provided when the change type is `ChangeType.Removed` or `Modified`.
+     * This will be a copy of the same event as `event` when a redaction has occurred and this will show its unredacted state.
+     */
+    readonly previousState?: any,
+}
+
+/**
+ * The BanList caches all of the rules that are active in a policy room so Mjolnir can refer to when applying bans etc.
+ * This cannot be used to update events in the modeled room, it is a readonly model of the policy room.
+ */
 export default class BanList {
     private rules: ListRule[] = [];
     private shortcode: string|null = null;
+    // A map of state events indexed first by state type and then state keys.
+    private state: Map<string, Map<string, any>> = new Map();
 
+    /**
+     * Construct a BanList, does not synchronize with the room.
+     * @param roomId The id of the policy room, i.e. a room containing MSC2313 policies.
+     * @param roomRef A sharable/clickable matrix URL that refers to the room.
+     * @param client A matrix client that is used to read the state of the room when `updateList` is called.
+     */
     constructor(public readonly roomId: string, public readonly roomRef, private client: MatrixClient) {
     }
 
+    /**
+     * The code that can be used to refer to this banlist in Mjolnir commands.
+     */
     public get listShortcode(): string {
         return this.shortcode || '';
+    }
+
+    /**
+     * Lookup the current rules cached for the list.
+     * @param stateType The event type e.g. m.room.rule.user.
+     * @param stateKey The state key e.g. entity:@bad:matrix.org
+     * @returns A state event if present or null.
+     */
+    private getState(stateType: string, stateKey: string) {
+        return this.state.get(stateType)?.get(stateKey);
+    }
+
+    /**
+     * Store this state event as part of the active room state for this BanList (used to cache rules).
+     * @param stateType The event type e.g. m.room.rule.user.
+     * @param stateKey The state key e.g. entity:@bad:matrix.org
+     * @param event A state event to store.
+     */
+    private setState(stateType: string, stateKey: string, event: any): void {
+        let typeTable = this.state.get(stateType);
+        if (typeTable) {
+            typeTable.set(stateKey, event);
+        } else {
+            this.state.set(stateType, new Map().set(stateKey, event));
+        }
     }
 
     public set listShortcode(newShortcode: string) {
@@ -71,8 +142,14 @@ export default class BanList {
         return [...this.serverRules, ...this.userRules, ...this.roomRules];
     }
 
-    public async updateList() {
+    /**
+     * Synchronise the model with the room representing the ban list by reading the current state of the room
+     * and updating the model to reflect the room.
+     * @returns A description of any rules that were added, modified or removed from the list as a result of this update.
+     */
+    public async updateList(): Promise<ListRuleChange[]> {
         this.rules = [];
+        let changes: ListRuleChange[] = [];
 
         const state = await this.client.getRoomState(this.roomId);
         for (const event of state) {
@@ -96,6 +173,37 @@ export default class BanList {
                 continue; // invalid/unknown
             }
 
+            const previousState = this.getState(event['type'], event['state_key']);
+            this.setState(event['type'], event['state_key'], event);
+            const changeType: null|ChangeType = (() => {
+                if (!previousState) {
+                    return ChangeType.Added;
+                } else if (previousState['event_id'] === event['event_id']) {
+                    if (event['unsigned']?.['redacted_because']) {
+                        return ChangeType.Removed;
+                    } else {
+                        // Nothing has changed.
+                        return null;
+                    }
+                } else {
+                    // Then the policy has been modified in some other way, possibly 'soft' redacted by a new event with empty content...
+                    if (Object.keys(event['content']).length === 0) {
+                        return ChangeType.Removed;
+                    } else {
+                        return ChangeType.Modified;
+                    }
+                }
+            })();
+
+            // If we haven't got any information about what the rule used to be, then it wasn't a valid rule to begin with
+            // and so will not have been used. Removing a rule like this therefore results in no change.
+            if (changeType === ChangeType.Removed && previousState?.unsigned?.rule) {
+                const sender = event.unsigned['redacted_because'] ? event.unsigned['redacted_because']['sender'] : event.sender;
+                changes.push({changeType, event, sender, rule: previousState.unsigned.rule,
+                    ... previousState ? {previousState} : {} });
+                // Event has no content and cannot be parsed as a ListRule.
+                continue;
+            }
             // It's a rule - parse it
             const content = event['content'];
             if (!content) continue;
@@ -107,8 +215,13 @@ export default class BanList {
             if (!entity || !recommendation) {
                 continue;
             }
-
-            this.rules.push(new ListRule(entity, recommendation, reason, kind));
+            const rule = new ListRule(entity, recommendation, reason, kind);
+            event.unsigned.rule = rule;
+            if (changeType) {
+                changes.push({rule, changeType, event, sender: event.sender, ... previousState ? {previousState} : {} });
+            }
+            this.rules.push(rule);
         }
+        return changes;
     }
 }

--- a/test/integration/banListTest.ts
+++ b/test/integration/banListTest.ts
@@ -31,26 +31,38 @@ describe("Test: Updating the BanList", function () {
         const banList = new BanList(banListId, banListId, mjolnir);
         mjolnir.setUserPowerLevel(await moderator.getUserId(), banListId, 100);
 
+        assert.equal(banList.allRules.length, 0);
+
         // Test adding a new rule
         await createPolicyRule(mjolnir, banListId, RULE_USER, '@added:localhost:9999', '');
         let changes: ListRuleChange[] = await banList.updateList();
         assert.equal(changes.length, 1, 'There should only be one change');
         assert.equal(changes[0].changeType, ChangeType.Added);
         assert.equal(changes[0].sender, await mjolnir.getUserId());
+        assert.equal(banList.userRules.length, 1);
+        assert.equal(banList.allRules.length, 1);
 
         // Test modifiying a rule
         let originalEventId = await createPolicyRule(mjolnir, banListId, RULE_USER, '@modified:localhost:9999', '');
         await banList.updateList();
-        let nextEventId = await createPolicyRule(mjolnir, banListId, RULE_USER, '@modified:localhost:9999', 'modified reason');
+        let modifyingEventId = await createPolicyRule(mjolnir, banListId, RULE_USER, '@modified:localhost:9999', 'modified reason');
         changes = await banList.updateList();
         assert.equal(changes.length, 1);
         assert.equal(changes[0].changeType, ChangeType.Modified);
         assert.equal(changes[0].previousState['event_id'], originalEventId, 'There should be a previous state event for a modified rule');
-        assert.equal(changes[0].event['event_id'], nextEventId);
+        assert.equal(changes[0].event['event_id'], modifyingEventId);
+        let modifyingAgainEventId = await createPolicyRule(mjolnir, banListId, RULE_USER, '@modified:localhost:9999', 'modified again');
+        changes = await banList.updateList();
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].changeType, ChangeType.Modified);
+        assert.equal(changes[0].previousState['event_id'], modifyingEventId, 'There should be a previous state event for a modified rule');
+        assert.equal(changes[0].event['event_id'], modifyingAgainEventId);
+        assert.equal(banList.userRules.length, 2, 'There should be two rules, one for @modified:localhost:9999 and one for @added:localhost:9999');
 
         // Test redacting a rule
         const redactThis = await createPolicyRule(mjolnir, banListId, RULE_USER, '@redacted:localhost:9999', '');
         await banList.updateList();
+        assert.equal(banList.userRules.filter(r => r.entity === '@redacted:localhost:9999').length, 1);
         await mjolnir.redactEvent(banListId, redactThis);
         changes = await banList.updateList();
         assert.equal(changes.length, 1);
@@ -59,22 +71,108 @@ describe("Test: Updating the BanList", function () {
         assert.equal(Object.keys(changes[0].event['content']).length, 0, 'Should show the new version of the event with redacted content');
         assert.notEqual(Object.keys(changes[0].previousState['content']), 0, 'Should have a copy of the unredacted state');
         assert.notEqual(changes[0].rule, undefined, 'The previous rule should be present');
+        assert.equal(banList.userRules.filter(r => r.entity === '@redacted:localhost:9999').length, 0, 'The rule should be removed.');
 
         // Test soft redaction of a rule
         const softRedactedEntity = '@softredacted:localhost:9999'
         await createPolicyRule(mjolnir, banListId, RULE_USER, softRedactedEntity, '');
         await banList.updateList();
-        await mjolnir.sendStateEvent(banListId, RULE_USER, softRedactedEntity, {});
+        assert.equal(banList.userRules.filter(r => r.entity === softRedactedEntity).length, 1);
+        await mjolnir.sendStateEvent(banListId, RULE_USER, `rule:${softRedactedEntity}`, {});
         changes = await banList.updateList();
         assert.equal(changes.length, 1);
         assert.equal(changes[0].changeType, ChangeType.Removed);
         assert.equal(Object.keys(changes[0].event['content']).length, 0, 'Should show the new version of the event with redacted content');
         assert.notEqual(Object.keys(changes[0].previousState['content']), 0, 'Should have a copy of the unredacted state');
         assert.notEqual(changes[0].rule, undefined, 'The previous rule should be present');
+        assert.equal(banList.userRules.filter(r => r.entity === softRedactedEntity).length, 0, 'The rule should have been removed');
 
         // Now test a double soft redaction just to make sure stuff doesn't explode
-        await mjolnir.sendStateEvent(banListId, RULE_USER, softRedactedEntity, {});
+        await mjolnir.sendStateEvent(banListId, RULE_USER, `rule:${softRedactedEntity}`, {});
         changes = await banList.updateList();
         assert.equal(changes.length, 0, "It shouldn't detect a double soft redaction as a change, it should be seen as adding an invalid rule.");
+        assert.equal(banList.userRules.filter(r => r.entity === softRedactedEntity).length, 0, 'The rule should have been removed');
+
+        // Test that different (old) rule types will be modelled as the latest event type.
+        originalEventId = await createPolicyRule(mjolnir, banListId, 'org.matrix.mjolnir.rule.user', '@old:localhost:9999', '');
+        changes = await banList.updateList();
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].changeType, ChangeType.Added);
+        assert.equal(banList.userRules.filter(r => r.entity === '@old:localhost:9999').length, 1);
+        modifyingEventId = await createPolicyRule(mjolnir, banListId, 'm.room.rule.user', '@old:localhost:9999', 'modified reason');
+        changes = await banList.updateList();
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].changeType, ChangeType.Modified);
+        assert.equal(changes[0].event['event_id'], modifyingEventId);
+        assert.equal(changes[0].previousState['event_id'], originalEventId, 'There should be a previous state event for a modified rule');
+        assert.equal(banList.userRules.filter(r => r.entity === '@old:localhost:9999').length, 1);
+        modifyingAgainEventId = await createPolicyRule(mjolnir, banListId, RULE_USER, '@old:localhost:9999', 'changes again');
+        changes = await banList.updateList();
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].changeType, ChangeType.Modified);
+        assert.equal(changes[0].event['event_id'], modifyingAgainEventId);
+        assert.equal(changes[0].previousState['event_id'], modifyingEventId, 'There should be a previous state event for a modified rule');
+        assert.equal(banList.userRules.filter(r => r.entity === '@old:localhost:9999').length, 1);
+    })
+    it("Will remove rules with old types when they are 'soft redacted' with a different but more recent event type.", async function () {
+        this.timeout(3000);
+        const mjolnir = config.RUNTIME.client!
+        const moderator = await newTestUser(false, "moderator");
+        const banListId = await mjolnir.createRoom({ invite: [await moderator.getUserId()]});
+        const banList = new BanList(banListId, banListId, mjolnir);
+        mjolnir.setUserPowerLevel(await moderator.getUserId(), banListId, 100);
+
+        const entity = '@old:localhost:9999';
+        let originalEventId = await createPolicyRule(mjolnir, banListId, 'm.room.rule.user', entity, '');
+        let changes = await banList.updateList();
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].changeType, ChangeType.Added);
+        assert.equal(banList.userRules.filter(rule => rule.entity === entity).length, 1, 'There should be a rule stored that we just added...')
+        let softRedactingEventId = await mjolnir.sendStateEvent(banListId, RULE_USER, `rule:${entity}`, {});
+        changes = await banList.updateList();
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].changeType, ChangeType.Removed);
+        assert.equal(changes[0].event['event_id'], softRedactingEventId);
+        assert.equal(changes[0].previousState['event_id'], originalEventId, 'There should be a previous state event for a modified rule');
+        assert.equal(banList.userRules.filter(rule => rule.entity === entity).length, 0, 'The rule should no longer be stored.');
+    })
+    it("A rule of the most recent type won't be deleted when an old rule is deleted for the same entity.", async function () {
+        this.timeout(3000);
+        const mjolnir = config.RUNTIME.client!
+        const moderator = await newTestUser(false, "moderator");
+        const banListId = await mjolnir.createRoom({ invite: [await moderator.getUserId()]});
+        const banList = new BanList(banListId, banListId, mjolnir);
+        mjolnir.setUserPowerLevel(await moderator.getUserId(), banListId, 100);
+
+        const entity = '@old:localhost:9999';
+        let originalEventId = await createPolicyRule(mjolnir, banListId, 'm.room.rule.user', entity, '');
+        let changes = await banList.updateList();
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].changeType, ChangeType.Added);
+        assert.equal(banList.userRules.filter(rule => rule.entity === entity).length, 1, 'There should be a rule stored that we just added...')
+        let updatedEventId = await createPolicyRule(mjolnir, banListId, RULE_USER, entity, '');
+        changes = await banList.updateList();
+        // If in the future you change this and it fails, it's really subjective whether this constitutes a modification, since the only thing that has changed
+        // is the rule type. The actual content is identical.
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].changeType, ChangeType.Modified);
+        assert.equal(changes[0].event['event_id'], updatedEventId);
+        assert.equal(changes[0].previousState['event_id'], originalEventId, 'There should be a previous state event for a modified rule');
+        assert.equal(banList.userRules.filter(rule => rule.entity === entity).length, 1, 'Only the latest version of the rule gets returned.');
+
+        // Now we delete the old version of the rule without consequence.
+        await mjolnir.sendStateEvent(banListId, 'm.room.rule.user', `rule:${entity}`, {});
+        changes = await banList.updateList();
+        assert.equal(changes.length, 0);
+        assert.equal(banList.userRules.filter(rule => rule.entity === entity).length, 1, 'The rule should still be active.');
+
+        // And we can still delete the new version of the rule.
+        let softRedactingEventId = await mjolnir.sendStateEvent(banListId, RULE_USER, `rule:${entity}`, {});
+        changes = await banList.updateList();
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].changeType, ChangeType.Removed);
+        assert.equal(changes[0].event['event_id'], softRedactingEventId);
+        assert.equal(changes[0].previousState['event_id'], updatedEventId, 'There should be a previous state event for a modified rule');
+        assert.equal(banList.userRules.filter(rule => rule.entity === entity).length, 0, 'The rule should no longer be stored.');
     })
 });

--- a/test/integration/banListTest.ts
+++ b/test/integration/banListTest.ts
@@ -1,0 +1,80 @@
+import { strict as assert } from "assert";
+
+import config from "../../src/config";
+import { newTestUser } from "./clientHelper";
+import { MatrixClient } from "matrix-bot-sdk";
+import  BanList, { ChangeType, ListRuleChange, RULE_USER } from "../../src/models/BanList";
+
+/**
+ * Create a policy rule in a policy room.
+ * @param client A matrix client that is logged in
+ * @param policyRoomId The room id to add the policy to.
+ * @param policyType The type of policy to add e.g. m.policy.rule.user. (Use RULE_USER though).
+ * @param entity The entity to ban e.g. @foo:example.org
+ * @param reason A reason for the rule e.g. 'Wouldn't stop posting spam links'
+ * @returns The event id of the newly created policy rule.
+ */
+async function createPolicyRule(client: MatrixClient, policyRoomId: string, policyType: string, entity: string, reason: string) {
+    return await client.sendStateEvent(policyRoomId, policyType, `rule:${entity}`, {
+        entity,
+        reason,
+        recommendation: 'm.ban'
+    });
+}
+
+describe("Test: Updating the BanList", function () {
+    it("Calculates what has changed correctly.", async function () {
+        this.timeout(10000);
+        const mjolnir = config.RUNTIME.client!
+        const moderator = await newTestUser(false, "moderator");
+        const banListId = await mjolnir.createRoom({ invite: [await moderator.getUserId()]});
+        const banList = new BanList(banListId, banListId, mjolnir);
+        mjolnir.setUserPowerLevel(await moderator.getUserId(), banListId, 100);
+
+        // Test adding a new rule
+        await createPolicyRule(mjolnir, banListId, RULE_USER, '@added:localhost:9999', '');
+        let changes: ListRuleChange[] = await banList.updateList();
+        assert.equal(changes.length, 1, 'There should only be one change');
+        assert.equal(changes[0].changeType, ChangeType.Added);
+        assert.equal(changes[0].sender, await mjolnir.getUserId());
+
+        // Test modifiying a rule
+        let originalEventId = await createPolicyRule(mjolnir, banListId, RULE_USER, '@modified:localhost:9999', '');
+        await banList.updateList();
+        let nextEventId = await createPolicyRule(mjolnir, banListId, RULE_USER, '@modified:localhost:9999', 'modified reason');
+        changes = await banList.updateList();
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].changeType, ChangeType.Modified);
+        assert.equal(changes[0].previousState['event_id'], originalEventId, 'There should be a previous state event for a modified rule');
+        assert.equal(changes[0].event['event_id'], nextEventId);
+
+        // Test redacting a rule
+        const redactThis = await createPolicyRule(mjolnir, banListId, RULE_USER, '@redacted:localhost:9999', '');
+        await banList.updateList();
+        await mjolnir.redactEvent(banListId, redactThis);
+        changes = await banList.updateList();
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].changeType, ChangeType.Removed);
+        assert.equal(changes[0].event['event_id'], redactThis, 'Should show the new version of the event with redacted content');
+        assert.equal(Object.keys(changes[0].event['content']).length, 0, 'Should show the new version of the event with redacted content');
+        assert.notEqual(Object.keys(changes[0].previousState['content']), 0, 'Should have a copy of the unredacted state');
+        assert.notEqual(changes[0].rule, undefined, 'The previous rule should be present');
+
+        // Test soft redaction of a rule
+        const softRedactedEntity = '@softredacted:localhost:9999'
+        await createPolicyRule(mjolnir, banListId, RULE_USER, softRedactedEntity, '');
+        await banList.updateList();
+        await mjolnir.sendStateEvent(banListId, RULE_USER, softRedactedEntity, {});
+        changes = await banList.updateList();
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].changeType, ChangeType.Removed);
+        assert.equal(Object.keys(changes[0].event['content']).length, 0, 'Should show the new version of the event with redacted content');
+        assert.notEqual(Object.keys(changes[0].previousState['content']), 0, 'Should have a copy of the unredacted state');
+        assert.notEqual(changes[0].rule, undefined, 'The previous rule should be present');
+
+        // Now test a double soft redaction just to make sure stuff doesn't explode
+        await mjolnir.sendStateEvent(banListId, RULE_USER, softRedactedEntity, {});
+        changes = await banList.updateList();
+        assert.equal(changes.length, 0, "It shouldn't detect a double soft redaction as a change, it should be seen as adding an invalid rule.");
+    })
+});


### PR DESCRIPTION
Only shows changes to lists made by other accounts (than the one used by Mjolnir).
Displays when rules are added, removed and modified by either replacing the state event or redacting them.

Looks like this:
![Selection_041](https://user-images.githubusercontent.com/50846879/141979758-8fe2dce9-cfa8-410f-8dc4-96d13ca9d35e.png)