### PR TITLE
make `roomIds` param on replaceRoomIdsWithPills a Set<string>

### DIFF
--- a/src/LogProxy.ts
+++ b/src/LogProxy.ts
@@ -36,7 +36,7 @@ export async function logMessage(level: LogLevel, module: string, message: strin
 
         const client = config.RUNTIME.client;
         const managementRoomId = await client.resolveRoom(config.managementRoom);
-        const roomIds = [managementRoomId, ...additionalRoomIds];
+        const roomIds = new Set([managementRoomId, ...additionalRoomIds]);
 
         let evContent: TextualMessageEventContent = {
             body: message,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -179,9 +179,7 @@ export async function getMessagesByUserIn(client: MatrixClient, sender: string, 
     }
 }
 
-export async function replaceRoomIdsWithPills(client: MatrixClient, text: string, roomIds: string[] | string, msgtype: MessageType = "m.text"): Promise<TextualMessageEventContent> {
-    if (!Array.isArray(roomIds)) roomIds = [roomIds];
-
+export async function replaceRoomIdsWithPills(client: MatrixClient, text: string, roomIds: Set<string> | string, msgtype: MessageType = "m.text"): Promise<TextualMessageEventContent> {
     const content: TextualMessageEventContent = {
         body: text,
         formatted_body: htmlEscape(text),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -179,7 +179,7 @@ export async function getMessagesByUserIn(client: MatrixClient, sender: string, 
     }
 }
 
-export async function replaceRoomIdsWithPills(client: MatrixClient, text: string, roomIds: Set<string> | string, msgtype: MessageType = "m.text"): Promise<TextualMessageEventContent> {
+export async function replaceRoomIdsWithPills(client: MatrixClient, text: string, roomIds: Set<string>, msgtype: MessageType = "m.text"): Promise<TextualMessageEventContent> {
     const content: TextualMessageEventContent = {
         body: text,
         formatted_body: htmlEscape(text),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -179,6 +179,18 @@ export async function getMessagesByUserIn(client: MatrixClient, sender: string, 
     }
 }
 
+/*
+ * Take an arbitrary string and a set of room IDs, and return a
+ * TextualMessageEventContent whose plaintext component replaces those room
+ * IDs with their canonical aliases, and whose html component replaces those
+ * room IDs with their matrix.to room pills.
+ *
+ * @param client The matrix client on which to query for room aliases
+ * @param text An arbitrary string to rewrite with room aliases and pills
+ * @param roomIds A set of room IDs to find and replace in `text`
+ * @param msgtype The desired message type of the returned TextualMessageEventContent
+ * @returns A TextualMessageEventContent with replaced room IDs
+ */
 export async function replaceRoomIdsWithPills(client: MatrixClient, text: string, roomIds: Set<string>, msgtype: MessageType = "m.text"): Promise<TextualMessageEventContent> {
     const content: TextualMessageEventContent = {
         body: text,

--- a/test/integration/utilsTest.ts
+++ b/test/integration/utilsTest.ts
@@ -1,0 +1,31 @@
+import { strict as assert } from "assert";
+
+import { UserID } from "matrix-bot-sdk";
+import config from "../../src/config";
+import { replaceRoomIdsWithPills } from "../../src/utils";
+
+describe("Test: utils", function() {
+    it("replaceRoomIdsWithPills correctly turns a room ID in to a pill", async function() {
+        this.timeout(20000);
+
+        await this.mjolnir.client.sendStateEvent(
+            this.mjolnir.managementRoomId,
+            "m.room.canonical_alias",
+            "",
+            { alias: config.managementRoom }
+        );
+
+        const out = await replaceRoomIdsWithPills(
+            this.mjolnir.client,
+            `it's fun here in ${this.mjolnir.managementRoomId}`,
+            new Set([this.mjolnir.managementRoomId])
+        );
+
+        const ourHomeserver = new UserID(await this.mjolnir.client.getUserId()).domain;
+        assert.equal(
+            out.formatted_body,
+            `it's fun here in <a href="https://matrix.to/#/${config.managementRoom}?via=${ourHomeserver}">${config.managementRoom}</a>`
+        );
+    });
+});
+


### PR DESCRIPTION
if `roomIds` has duplicates in it, the replacements on L196 and L198 will break the previous replacements.

example:
```
!asd:matrix.org
```
becomes
```
<a href=\"https://matrix.to/#/!asd:matrix.org?via=matrix.org\">!asd:matrix.org</a>
```
becomes
```
<a href=\"https://matrix.to/#/<a href=\"https://matrix.to/#/!asd:matrix.org?via=matrix.org\">!asd:matrix.org</a>?via=matrix.org\"><a href=\"https://matrix.to/#/!asd:matrix.org?via=matrix.org\">!asd:matrix.org</a></a>
```
et cetera