### PR TITLE
consistently use 'alias' in ensureAliasedRoomExists

### DIFF
--- a/test/integration/mjolnirSetupUtils.ts
+++ b/test/integration/mjolnirSetupUtils.ts
@@ -39,7 +39,7 @@ export async function ensureAliasedRoomExists(client: MatrixClient, alias: strin
             let roomId = await client.createRoom({
                 visibility: "public",
             });
-            await client.createRoomAlias(config.managementRoom, roomId);
+            await client.createRoomAlias(alias, roomId);
             return roomId
         }
         throw e;


### PR DESCRIPTION
I assume this was the intention for this function, and doing this allows integration tests to use this function for other things