### PR TITLE
Apply bans before ACLs

### DIFF
--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -620,8 +620,8 @@ export class Mjolnir {
 
         let hadErrors = false;
 
-        const aclErrors = await applyServerAcls(this.banLists, Object.keys(this.protectedRooms), this);
         const banErrors = await applyUserBans(this.banLists, Object.keys(this.protectedRooms), this);
+        const aclErrors = await applyServerAcls(this.banLists, Object.keys(this.protectedRooms), this);
         const redactionErrors = await this.processRedactionQueue();
         hadErrors = hadErrors || await this.printActionResult(aclErrors, "Errors updating server ACLs:");
         hadErrors = hadErrors || await this.printActionResult(banErrors, "Errors updating member bans:");


### PR DESCRIPTION
In my instance it takes 2x longer to apply ACLs than new bans (16s vs. 8s). However, I very infrequently apply ACLs.
The goal of this change is to reduce the time to apply moderation action.