### PR TITLE
Use `glob_to_regex` from `matrix_common`

### DIFF
--- a/synapse_antispam/mjolnir/list_rule.py
+++ b/synapse_antispam/mjolnir/list_rule.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from synapse.util import glob_to_regex
+from matrix_common.regex import glob_to_regex
 
 RECOMMENDATION_BAN = "m.ban"
 RECOMMENDATION_BAN_TYPES = [RECOMMENDATION_BAN, "org.matrix.mjolnir.ban"]

--- a/synapse_antispam/setup.py
+++ b/synapse_antispam/setup.py
@@ -7,5 +7,7 @@ setup(
     description="Mjolnir Antispam",
     include_package_data=True,
     zip_safe=True,
-    install_requires=[],
+    install_requires=[
+        "matrix-common >= 1.0.0"
+    ],
 )

--- a/synapse_antispam/setup.py
+++ b/synapse_antispam/setup.py
@@ -8,6 +8,6 @@ setup(
     include_package_data=True,
     zip_safe=True,
     install_requires=[
-        "matrix-common >= 1.0.0"
+        "matrix-common ~= 1.0"
     ],
 )


### PR DESCRIPTION
This function has moved to matrix-common since Synapse v1.50.0rc1.

Fixes #173.

We should probably make a note on `matrix_common` that Mjolnir is using it, in case we ever need to know for compatibility reasons.