### PR TITLE
Use public Synapse imports for `UserID` and `run_as_background_process`

### DIFF
--- a/synapse_antispam/mjolnir/antispam.py
+++ b/synapse_antispam/mjolnir/antispam.py
@@ -16,7 +16,7 @@
 import logging
 from .list_rule import ALL_RULE_TYPES, RECOMMENDATION_BAN
 from .ban_list import BanList
-from synapse.types import UserID
+from synapse.module_api import UserID
 
 logger = logging.getLogger("synapse.contrib." + __name__)
 

--- a/synapse_antispam/mjolnir/ban_list.py
+++ b/synapse_antispam/mjolnir/ban_list.py
@@ -16,7 +16,7 @@
 import logging
 from .list_rule import ListRule, ALL_RULE_TYPES, USER_RULE_TYPES, SERVER_RULE_TYPES, ROOM_RULE_TYPES
 from twisted.internet import defer
-from synapse.metrics.background_process_metrics import run_as_background_process
+from synapse.module_api import run_as_background_process
 
 logger = logging.getLogger("synapse.contrib." + __name__)
 


### PR DESCRIPTION
The general rule is: `synapse.module_api` is OK, but anywhere else is not.

Luckily the other two things are already exported for public use. We don't guarantee the stability/existence of functions in other parts of the code.

Related: #173, #174.