### PR TITLE
Use MSC2313 m.policy.rule.* for rules in antispam.

### DIFF
--- a/synapse_antispam/mjolnir/list_rule.py
+++ b/synapse_antispam/mjolnir/list_rule.py
@@ -18,12 +18,12 @@ from synapse.util import glob_to_regex
 RECOMMENDATION_BAN = "m.ban"
 RECOMMENDATION_BAN_TYPES = [RECOMMENDATION_BAN, "org.matrix.mjolnir.ban"]
 
-RULE_USER = "m.room.rule.user"
-RULE_ROOM = "m.room.rule.room"
-RULE_SERVER = "m.room.rule.server"
-USER_RULE_TYPES = [RULE_USER, "org.matrix.mjolnir.rule.user"]
-ROOM_RULE_TYPES = [RULE_ROOM, "org.matrix.mjolnir.rule.room"]
-SERVER_RULE_TYPES = [RULE_SERVER, "org.matrix.mjolnir.rule.server"]
+RULE_USER = "m.policy.rule.user"
+RULE_ROOM = "m.policy.rule.room"
+RULE_SERVER = "m.policy.rule.server"
+USER_RULE_TYPES = [RULE_USER, "m.room.rule.user", "org.matrix.mjolnir.rule.user"]
+ROOM_RULE_TYPES = [RULE_ROOM, "m.room.rule.room", "org.matrix.mjolnir.rule.room"]
+SERVER_RULE_TYPES = [RULE_SERVER, "m.room.rule.server", "org.matrix.mjolnir.rule.server"]
 ALL_RULE_TYPES = [*USER_RULE_TYPES, *ROOM_RULE_TYPES, *SERVER_RULE_TYPES]
 
 def recommendation_to_stable(recommendation):


### PR DESCRIPTION
We recently changed banlists to prefer this prefix but forgot to update antispam to recognise them https://github.com/matrix-org/mjolnir/commit/0bbfe93a4b992417287ee699fb3604bf92366f82. 