### PR TITLE
Add support for native E2E

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,12 @@ homeserver.
 
 ## Bot configuration
 
-It is recommended to use [Pantalaimon](https://github.com/matrix-org/pantalaimon) so your
-management room can be encrypted. This also applies if you are looking to moderate an encrypted
-room. 
+It is recommended to enable encryption support so your management room can be encrypted.
+This also applies if you are looking to moderate an encrypted room. 
 
-If you aren't using encrypted rooms anywhere, get an access token by opening Riot in an
-incognito/private window and log in as the bot. From the Help & Support tab in settings there
-is an access token field - copy and paste that into your config. Most importantly: do not log
-out and instead just close the window. Logging out will make the token you just copied useless.
+You can get an an access token by opening Element in an incognito/private window and log in as the bot.
+From the Help & Support tab in settings there is an access token field - copy and paste that into your config.
+Most importantly: do not log out and instead just close the window. Logging out will make the token you just copied useless.
 
 **Note**: Mjolnir expects to be free of rate limiting - see [Synapse #6286](https://github.com/matrix-org/synapse/issues/6286)
 for information on how to achieve this.

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,16 +1,22 @@
 # Where the homeserver is located (client-server URL). This should point at
-# pantalaimon if you're using that.
+# Pantalaimon if you're using that.
 homeserverUrl: "https://matrix.org"
 
 
-# Where the homeserver is located (client-server URL). NOT panalaimon.
+# Where the homeserver is located (client-server URL). NOT Pantalaimon.
 rawHomeserverUrl: "https://matrix.org"
 
 
 # The access token for the bot to use. Do not populate if using Pantalaimon.
 accessToken: "YOUR_TOKEN_HERE"
 
-# Pantalaimon options (https://github.com/matrix-org/pantalaimon)
+# Enable support for handling encrypted rooms. This cannot be enabled if
+# Pantalaimon is enabled.
+encryption:
+  enabled: false
+
+# Pantalaimon options (https://github.com/matrix-org/pantalaimon). This cannot be
+# enabled if encryption is enabled.
 pantalaimon:
   # If true, accessToken above is ignored and the username/password below will be
   # used instead. The access token of the bot will be stored in the dataPath.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "html-to-text": "^8.0.0",
     "js-yaml": "^4.1.0",
     "jsdom": "^16.6.0",
-    "matrix-bot-sdk": "^0.5.19"
+    "matrix-bot-sdk": "^v0.6.0-beta.4"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,9 @@ interface IConfig {
         username: string;
         password: string;
     };
+    encryption: {
+        enabled: boolean;
+    };
     dataPath: string;
     acceptInvitesFromGroup: string;
     autojoinOnlyIfManager: boolean;
@@ -95,6 +98,9 @@ const defaultConfig: IConfig = {
         use: false,
         username: "",
         password: "",
+    },
+    encryption: {
+        enabled: false,
     },
     dataPath: "/data/storage",
     acceptInvitesFromGroup: '+example:example.org',

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,6 +70,11 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@napi-rs/cli@^2.2.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/cli/-/cli-2.4.0.tgz#a74d991e12871d6fb8eb32b33cc53a9c105b1921"
+  integrity sha512-rq4ivqWY7KWG104gRxTmWyehE4eUxJ/mBJx81r3PeghtLZ11NpJNuvF9kSvsol8hTjJQ7CWlF2plQ20I9rMOng==
+
 "@selderee/plugin-htmlparser2@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz#27e994afd1c2cb647ceb5406a185a5574188069d"
@@ -82,6 +87,14 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@turt2live/matrix-sdk-crypto-nodejs@^0.1.0-beta.8":
+  version "0.1.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@turt2live/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.1.0-beta.8.tgz#a243a91183ebef6ede11954d6f0f668664f15554"
+  integrity sha512-bjeYDZ0iwvdTLH9eIBW1VXRea7CeZ22sqRr9sE+5r/hO2gBfGJ/1Ygg9z2J9wvI1qSSCmAEFlumPnJlkg0E0mg==
+  dependencies:
+    "@napi-rs/cli" "^2.2.0"
+    shelljs "^0.8.4"
 
 "@types/axios@^0.14.0":
   version "0.14.0"
@@ -119,7 +132,7 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express@^4.17.7":
+"@types/express@^4.17.13":
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
   integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
@@ -294,6 +307,11 @@ ajv@^8.0.1:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
+
+another-json@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/another-json/-/another-json-0.2.0.tgz#b5f4019c973b6dd5c6506a2d93469cb6d32aeedc"
+  integrity sha1-tfQBnJc7bdXGUGotk0acttMq7tw=
 
 ansi-colors@4.1.1, ansi-colors@^4.1.1:
   version "4.1.1"
@@ -1217,7 +1235,7 @@ glob@7.1.7:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.1, glob@^7.1.3:
+glob@^7.0.0, glob@^7.1.1, glob@^7.1.3:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -1435,6 +1453,11 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -1451,6 +1474,13 @@ is-core-module@^2.2.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.7.0.tgz#3c0ef7d31b4acfc574f80c58409d568a836848e3"
   integrity sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.8.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
+  integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
   dependencies:
     has "^1.0.3"
 
@@ -1755,12 +1785,14 @@ make-error@^1.1.1:
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
-matrix-bot-sdk@^0.5.19:
-  version "0.5.19"
-  resolved "https://registry.yarnpkg.com/matrix-bot-sdk/-/matrix-bot-sdk-0.5.19.tgz#6ce13359ab53ea0af9dc3ebcbe288c5f6d9c02c6"
-  integrity sha512-RIPyvQPkOVp2yTKeDgp5rcn6z/DiKdHb6E8c69K+utai8ypRGtfDRj0PGqP+1XzqC9Wb1OFrESCUB5t0ffdC9g==
+matrix-bot-sdk@^v0.6.0-beta.4:
+  version "0.6.0-beta.4"
+  resolved "https://registry.yarnpkg.com/matrix-bot-sdk/-/matrix-bot-sdk-0.6.0-beta.4.tgz#839c5a190817a88fd30088ba86ca2d2a59ecc2b9"
+  integrity sha512-Hf3RdAO+CxUERWky9zdy6D7z7ANjx/ynFERCRMr4oPj2fVwioEQQA9RQpZw8v7kSOgEiPJPFrjhPJ5oM97ym6A==
   dependencies:
-    "@types/express" "^4.17.7"
+    "@turt2live/matrix-sdk-crypto-nodejs" "^0.1.0-beta.8"
+    "@types/express" "^4.17.13"
+    another-json "^0.2.0"
     chalk "^4.1.0"
     express "^4.17.1"
     glob-to-regexp "^0.4.1"
@@ -2062,7 +2094,7 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
+path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -2201,6 +2233,13 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
+
 regexpp@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
@@ -2263,6 +2302,15 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve@^1.1.6:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.21.0.tgz#b51adc97f3472e6a5cf4444d34bc9d6b9037591f"
+  integrity sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==
+  dependencies:
+    is-core-module "^2.8.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 resolve@^1.3.2:
   version "1.20.0"
@@ -2391,6 +2439,15 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shelljs@^0.8.4:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 sigmund@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
@@ -2518,6 +2575,11 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
Fixes #185 

This PR adds support for the new native E2E built into the bot-sdk, which removes the need for pan. I've tested this works locally, but it's not extensively battle tested. I've also:

- Kept the pan config, but added a check to avoid trying to use pan and this feature concurrrently.
- Changed the README to recommend admins use this feature, as it's easier to setup.

This could potentially be enabled by default, but I didn't want to change things for existing users.

I cribbed fromhttps://github.com/turt2live/matrix-bot-sdk/blob/master/examples/encryption_bot.ts when writing this code.