### PR TITLE
Stop reacting to reports Mjolnir didn't send in report manager.

### DIFF
--- a/src/report/ReportManager.ts
+++ b/src/report/ReportManager.ts
@@ -142,6 +142,11 @@ export class ReportManager {
         let initialNoticeReport: IReport | undefined, confirmationReport: IReportWithAction | undefined;
         try {
             let originalEvent = await this.mjolnir.client.getEvent(roomId, relation.event_id);
+            if (originalEvent.sender !== await this.mjolnir.client.getUserId()) {
+                // Let's not handle reactions to events we didn't send as
+                // some setups have two or more Mjolnir's in the same management room.
+                return;
+            }
             if (!("content" in originalEvent)) {
                 return;
             }


### PR DESCRIPTION
We have gotten feedback that some homeservers are using more than one bot in the management room that Mjolnir is overreacting to. So in this patch we stop Mjolnir handling reactions to events the Mjolnir didn't send in the report manager. 