### PR TITLE
Improvements to manual testing with the test:manual script.

### DIFF
--- a/config/harness.yaml
+++ b/config/harness.yaml
@@ -9,6 +9,9 @@ homeserverUrl: "http://localhost:8081"
 # Where the homeserver is located (client-server URL). NOT pantalaimon.
 rawHomeserverUrl: "http://localhost:8081"
 
+# README: We use the Pantalaimon client WITHOUT Pantalaimon itself in tests (and the manual test)
+# as an easy way to login with passwords from the config without having
+# to resolve a chicken-vs-egg problem in regards to access tokens.
 # Pantalaimon options (https://github.com/matrix-org/pantalaimon)
 pantalaimon:
   # If true, accessToken above is ignored and the username/password below will be

--- a/mx-tester.yml
+++ b/mx-tester.yml
@@ -1,5 +1,4 @@
 name: mjolnir
-
 up:
   before:
     # Launch the reverse proxy, listening for connections *only* on the local host.
@@ -19,6 +18,8 @@ homeserver:
   server_name: localhost:9999
   public_baseurl: http://localhost:9999
   registration_shared_secret: REGISTRATION_SHARED_SECRET
+  # Make manual testing easier
+  enable_registration: true
 
   # Getting rid of throttling.
   rc_message:

--- a/test/integration/clientHelper.ts
+++ b/test/integration/clientHelper.ts
@@ -1,6 +1,5 @@
 import axios from "axios";
 import { HmacSHA1 } from "crypto-js";
-import e from "express";
 import { LogService, MatrixClient, MemoryStorageProvider, PantalaimonClient } from "matrix-bot-sdk";
 import config from "../../src/config";
 
@@ -43,6 +42,7 @@ export async function registerUser(username: string, displayname: string, passwo
             throw ex;
         }
     }
+    throw new Error(`Retried registration ${REGISTRATION_ATTEMPTS} times, is Mjolnir or Synapse misconfigured?`);
 }
 
 /**

--- a/test/integration/mjolnirSetupUtils.ts
+++ b/test/integration/mjolnirSetupUtils.ts
@@ -50,12 +50,12 @@ export async function ensureAliasedRoomExists(client: MatrixClient, alias: strin
 
 async function configureMjolnir() {
     try {
-        await registerUser('mjolnir', 'mjolnir', 'mjolnir', true)
+        await registerUser(config.pantalaimon.username, config.pantalaimon.username, config.pantalaimon.password, true)
     } catch (e) {
         if (e.isAxiosError) {
             console.log('Received error while registering', e.response.data || e.response);
             if (e.response.data && e.response.data.errcode === 'M_USER_IN_USE') {
-                console.log('mjolnir already registered, skipping');
+                console.log(`${config.pantalaimon.username} already registered, skipping`);
                 return;
             }
         }


### PR DESCRIPTION
- Use the configured username & password when registering the test user to run Mjolnir with (was hardcoded).
- Remove bogus imports from the helper that have accidentally been introduced with VSCode.
- Keep `enable_registration: true` in the homeserver config to save time.