### PR TITLE
Add Protection against mention flooding

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -78,11 +78,11 @@ interface IConfig {
         address: string;
         abuseReporting: {
             enabled: boolean;
-        };
+        }
         ruleServer?: {
             enabled: boolean;
-        };
-    };
+        }
+    }
 
     /**
      * Config options only set at runtime. Try to avoid using the objects

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,10 +57,6 @@ interface IConfig {
         confirmWildcardBan: boolean;
     };
     protections: {
-        mentionFlood: {
-            maxMentionsPerMessage: number;
-            minutesBeforeTrusting: number;
-        };
         wordlist: {
             words: string[];
             minutesBeforeTrusting: number;
@@ -126,10 +122,6 @@ const defaultConfig: IConfig = {
         confirmWildcardBan: true,
     },
     protections: {
-        mentionFlood: {
-            maxMentionsPerMessage: 20,
-            minutesBeforeTrusting: 20,
-        },
         wordlist: {
             words: [],
             minutesBeforeTrusting: 20

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,6 +57,10 @@ interface IConfig {
         confirmWildcardBan: boolean;
     };
     protections: {
+        mentionFlood: {
+            maxMentionsPerMessage: number;
+            minutesBeforeTrusting: number;
+        };
         wordlist: {
             words: string[];
             minutesBeforeTrusting: number;
@@ -78,11 +82,11 @@ interface IConfig {
         address: string;
         abuseReporting: {
             enabled: boolean;
-        }
+        };
         ruleServer?: {
             enabled: boolean;
-        }
-    }
+        };
+    };
 
     /**
      * Config options only set at runtime. Try to avoid using the objects
@@ -122,6 +126,10 @@ const defaultConfig: IConfig = {
         confirmWildcardBan: true,
     },
     protections: {
+        mentionFlood: {
+            maxMentionsPerMessage: 20,
+            minutesBeforeTrusting: 20,
+        },
         wordlist: {
             words: [],
             minutesBeforeTrusting: 20

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -29,13 +29,13 @@ const DEFAULT_REDACT = true;
 const DEFAULT_ACTION = "ban";
 
 const LOCALPART_REGEX = "[0-9a-z-.=_/]+";
-const HISTORIC_LOCALPART_REGEX = "([\u0021-\u0039]|[\u003B-\u007E])+";
+const HISTORIC_LOCALPART_REGEX = "([\\u0021-\\u0039]|[\\u003B-\\u007E])+";
 // https://github.com/johno/domain-regex/blob/8a6984c8fa1fe8481a4b99be0fa7f2a01ee17517/index.js
-const DOMAIN_REGEX = "(\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b)";
+const DOMAIN_REGEX = "(\\b((?=[a-z0-9-]{1,63}\\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,63}\\b)";
 // https://stackoverflow.com/a/5284410
-const IPV4_REGEX = "(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))";
+const IPV4_REGEX = "(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))";
 // https://stackoverflow.com/a/17871737
-const IPV6_REGEX = "(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))";
+const IPV6_REGEX = "(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))";
 const PORT_REGEX = "(:[0-9]+)?";
 
 
@@ -52,7 +52,7 @@ export class MentionFlood implements IProtection {
     private mention: RegExp;
 
     constructor() {
-        this.mention = new RegExp(`@(${LOCALPART_REGEX}|${HISTORIC_LOCALPART_REGEX}):(${DOMAIN_REGEX}|${IPV4_REGEX}|${IPV6_REGEX})${PORT_REGEX}`, "g");
+        this.mention = new RegExp(`@(${LOCALPART_REGEX}|${HISTORIC_LOCALPART_REGEX}):(${DOMAIN_REGEX}|${IPV4_REGEX}|${IPV6_REGEX})${PORT_REGEX}`, "gi");
     }
 
     public get name(): string {

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -72,7 +72,7 @@ export class MentionFlood implements IProtection {
                 if (isTrueJoinEvent(event)) {
                     const now = new Date();
                     this.justJoined.get(roomId)?.set(event['state_key'], now);
-                    LogService.info("MentionFlood", `${htmlEscape(event['event_id'])} joined ${roomId} at ${now.toDateString()}`);
+                    LogService.info("MentionFlood", `${htmlEscape(event['state_key'])} joined ${roomId} at ${now.toDateString()}`);
                 } else if (content['membership'] === 'leave' || content['membership'] === 'ban') {
                     this.justJoined.get(roomId)?.delete(event['sender']);
                 }
@@ -93,7 +93,7 @@ export class MentionFlood implements IProtection {
                     const now = new Date();
                     if (now.valueOf() - joinTime.valueOf() > minsBeforeTrusting * 60 * 1000) {
                         this.justJoined.get(roomId)?.delete(event['sender']); // Remove the user
-                        LogService.info("MentionFlood", `${htmlEscape(event['event_id'])} is no longer considered suspect`);
+                        LogService.info("MentionFlood", `${htmlEscape(event['sender'])} is no longer considered suspect`);
                         return;
                     }
 
@@ -111,29 +111,29 @@ export class MentionFlood implements IProtection {
                 const action = this.settings.action.value !== "" ? this.settings.action.value : DEFAULT_ACTION;
                 switch (action) {
                     case "ban": {
-                        await logMessage(LogLevel.WARN, "MentionFlood", `Banning ${htmlEscape(event['event_id'])} for mention flood violation in ${roomId}.`);
+                        await logMessage(LogLevel.WARN, "MentionFlood", `Banning ${htmlEscape(event['sender'])} for mention flood violation in ${roomId}.`);
                         if (!config.noop) {
                             await mjolnir.client.banUser(event['sender'], roomId, "Mention Flood violation");
                         } else {
-                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to ban ${htmlEscape(event['event_id'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to ban ${htmlEscape(event['sender'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
                         }
                         break;
                     }
                     case "kick": {
-                        await logMessage(LogLevel.WARN, "MentionFlood", `Kicking ${htmlEscape(event['event_id'])} for mention flood violation in ${roomId}.`);
+                        await logMessage(LogLevel.WARN, "MentionFlood", `Kicking ${htmlEscape(event['sender'])} for mention flood violation in ${roomId}.`);
                         if (!config.noop) {
                             await mjolnir.client.kickUser(event['sender'], roomId, "Mention Flood violation");
                         } else {
-                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to kick ${htmlEscape(event['event_id'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to kick ${htmlEscape(event['sender'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
                         }
                         break;
                     }
                     case "warn": {
-                        await logMessage(LogLevel.WARN, "MentionFlood", `Warning ${htmlEscape(event['event_id'])} for mention flood violation in ${roomId}.`);
+                        await logMessage(LogLevel.WARN, "MentionFlood", `Warning ${htmlEscape(event['sender'])} for mention flood violation in ${roomId}.`);
                         if (!config.noop) {
                             // await mjolnir.client.banUser(event['sender'], roomId, "Mention Flood violation");
                         } else {
-                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to warn ${htmlEscape(event['event_id'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to warn ${htmlEscape(event['sender'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
                         }
                         break;
                     }

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IProtection } from "./IProtection";
+import { Protection } from "./IProtection";
 import { Mjolnir } from "../Mjolnir";
 import { LogLevel, LogService } from "matrix-bot-sdk";
 import { logMessage } from "../LogProxy";
@@ -38,7 +38,7 @@ const IPV6_REGEX = "(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:
 const PORT_REGEX = "(:[0-9]+)?";
 
 
-export class MentionFlood implements IProtection {
+export class MentionFlood extends Protection {
 
     settings = {
         minutesBeforeTrusting: new NumberProtectionSetting(DEFAULT_MINUTES_BEFORE_TRUSTING),
@@ -51,11 +51,17 @@ export class MentionFlood implements IProtection {
     private mention: RegExp;
 
     constructor() {
+        super();
         this.mention = new RegExp(`@${LOCALPART_REGEX}:(${DOMAIN_REGEX}|${IPV4_REGEX}|${IPV6_REGEX})${PORT_REGEX}`, "gi");
     }
 
     public get name(): string {
         return 'MentionFlood';
+    }
+
+    public get description(): string {
+        return "If a user posts more mentions than a set amount of time after joining, they " +
+            "will be banned from that room.  This will not publish the ban to a ban list.";
     }
 
     public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any> {

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -62,8 +62,8 @@ export class MentionFlood extends Protection {
     }
 
     public get description(): string {
-        return "If a user posts more mentions than a set amount of time after joining, they " +
-            "will be banned from that room.  This will not publish the ban to a ban list.";
+        return `Protects against recently joined users attempting to ping too many other users at the same time. 
+        This will not publish bans to the ban list.`;
     }
 
     public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any> {

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -18,7 +18,6 @@ limitations under the License.
 import { Protection } from "./IProtection";
 import { Mjolnir } from "../Mjolnir";
 import { LogLevel, LogService } from "matrix-bot-sdk";
-import { logMessage } from "../LogProxy";
 import config from "../config";
 import { htmlEscape, isTrueJoinEvent } from "../utils";
 import { BooleanProtectionSetting, NumberProtectionSetting, OptionListProtectionSetting } from "./ProtectionSettings";
@@ -65,7 +64,6 @@ export class MentionFlood extends Protection {
     }
 
     public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any> {
-
         const content = event['content'] || {};
         const minsBeforeTrusting = this.settings.minutesBeforeTrusting.value;
 
@@ -117,25 +115,25 @@ export class MentionFlood extends Protection {
                 const action = this.settings.action.value !== "" ? this.settings.action.value : DEFAULT_ACTION;
                 switch (action) {
                     case "ban": {
-                        await logMessage(LogLevel.WARN, "MentionFlood", `Banning ${htmlEscape(event['sender'])} for mention flood violation in ${roomId}.`);
+                        await mjolnir.logMessage(LogLevel.WARN, "MentionFlood", `Banning ${htmlEscape(event['sender'])} for mention flood violation in ${roomId}.`);
                         if (!config.noop) {
                             await mjolnir.client.banUser(event['sender'], roomId, "Mention Flood violation");
                         } else {
-                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to ban ${htmlEscape(event['sender'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                            await mjolnir.logMessage(LogLevel.WARN, "MentionFlood", `Tried to ban ${htmlEscape(event['sender'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
                         }
                         break;
                     }
                     case "kick": {
-                        await logMessage(LogLevel.WARN, "MentionFlood", `Kicking ${htmlEscape(event['sender'])} for mention flood violation in ${roomId}.`);
+                        await mjolnir.logMessage(LogLevel.WARN, "MentionFlood", `Kicking ${htmlEscape(event['sender'])} for mention flood violation in ${roomId}.`);
                         if (!config.noop) {
                             await mjolnir.client.kickUser(event['sender'], roomId, "Mention Flood violation");
                         } else {
-                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to kick ${htmlEscape(event['sender'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                            await mjolnir.logMessage(LogLevel.WARN, "MentionFlood", `Tried to kick ${htmlEscape(event['sender'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
                         }
                         break;
                     }
                     case "warn": {
-                        await logMessage(LogLevel.WARN, "MentionFlood", `${htmlEscape(event['sender'])} triggered the mention flood protection in ${roomId}.`);
+                        await mjolnir.logMessage(LogLevel.WARN, "MentionFlood", `${htmlEscape(event['sender'])} triggered the mention flood protection in ${roomId}.`);
                         break;
                     }
                 }
@@ -145,7 +143,7 @@ export class MentionFlood extends Protection {
                 if (!config.noop && this.settings.redact.value) {
                     await mjolnir.client.redactEvent(roomId, event['event_id'], "spam");
                 } else {
-                    await logMessage(LogLevel.WARN, "MentionFlood", `Tried to redact ${htmlEscape(event['event_id'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                    await mjolnir.logMessage(LogLevel.WARN, "MentionFlood", `Tried to redact ${htmlEscape(event['event_id'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
                 }
             }
         }

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -1,0 +1,116 @@
+/*
+Copyright 2020 Emi Tatsuo Simpson et al.
+Copyright 2022 Marcel Radzio
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { IProtection } from "./IProtection";
+import { Mjolnir } from "../Mjolnir";
+import { LogLevel, LogService } from "matrix-bot-sdk";
+import { logMessage } from "../LogProxy";
+import config from "../config";
+import { isTrueJoinEvent } from "../utils";
+
+const LOCALPART_REGEX = "[0-9a-z-.=_/]+";
+// https://github.com/johno/domain-regex/blob/8a6984c8fa1fe8481a4b99be0fa7f2a01ee17517/index.js
+const DOMAIN_REGEX = "(\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b)";
+// https://stackoverflow.com/a/5284410
+const IPV4_REGEX = "(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))";
+// https://stackoverflow.com/a/17871737
+const IPV6_REGEX = "(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))";
+const PORT_REGEX = "(:[0-9]+)?";
+
+
+export class MentionFlood implements IProtection {
+
+    settings = {};
+
+    private justJoined: { [roomId: string]: { [username: string]: Date; }; } = {};
+    private mention: RegExp;
+
+    constructor() {
+        this.mention = new RegExp(`@${LOCALPART_REGEX}:(${DOMAIN_REGEX}|${IPV4_REGEX}|${IPV6_REGEX})${PORT_REGEX}`, "g");
+    }
+
+    public get name(): string {
+        return 'MentionFlood';
+    }
+
+    public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any> {
+
+        const content = event['content'] || {};
+        const minsBeforeTrusting = config.protections.mentionFlood.minutesBeforeTrusting;
+
+        if (minsBeforeTrusting > 0) {
+            if (!this.justJoined[roomId]) this.justJoined[roomId] = {};
+
+            // When a new member logs in, store the time they joined.  This will be useful
+            // when we need to check if a message was sent within 20 minutes of joining
+            if (event['type'] === 'm.room.member') {
+                if (isTrueJoinEvent(event)) {
+                    const now = new Date();
+                    this.justJoined[roomId][event['state_key']] = now;
+                    LogService.info("MentionFlood", `${event['state_key']} joined ${roomId} at ${now.toDateString()}`);
+                } else if (content['membership'] === 'leave' || content['membership'] === 'ban') {
+                    delete this.justJoined[roomId][event['sender']];
+                }
+
+                return;
+            }
+        }
+
+        if (event['type'] === 'm.room.message') {
+            const message = content['formatted_body'] || content['body'] || null;
+
+            // Check conditions first
+            if (minsBeforeTrusting > 0) {
+                const joinTime = this.justJoined[roomId][event['sender']];
+                if (joinTime) { // Disregard if the user isn't recently joined
+
+                    // Check if they did join recently, was it within the timeframe
+                    const now = new Date();
+                    if (now.valueOf() - joinTime.valueOf() > minsBeforeTrusting * 60 * 1000) {
+                        delete this.justJoined[roomId][event['sender']]; // Remove the user
+                        LogService.info("MentionFlood", `${event['sender']} is no longer considered suspect`);
+                        return;
+                    }
+
+                } else {
+                    // The user isn't in the recently joined users list, no need to keep
+                    // looking
+                    return;
+                }
+            }
+
+
+            // Perform the test
+            const maxMentionsPerMessage = config.protections.mentionFlood.maxMentionsPerMessage;
+            if (message && message.match(this.mention).length > maxMentionsPerMessage) {
+                await logMessage(LogLevel.WARN, "MentionFlood", `Banning ${event['sender']} for mention flood violation in ${roomId}.`);
+                if (!config.noop) {
+                    await mjolnir.client.banUser(event['sender'], roomId, "Mention Flood violation");
+                } else {
+                    await logMessage(LogLevel.WARN, "MentionFlood", `Tried to ban ${event['sender']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                }
+
+                // Redact the event
+                if (!config.noop) {
+                    await mjolnir.client.redactEvent(roomId, event['event_id'], "spam");
+                } else {
+                    await logMessage(LogLevel.WARN, "MentionFlood", `Tried to redact ${event['event_id']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                }
+            }
+        }
+    }
+}

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -29,7 +29,6 @@ const DEFAULT_REDACT = true;
 const DEFAULT_ACTION = "ban";
 
 const LOCALPART_REGEX = "[0-9a-z-.=_/]+";
-const HISTORIC_LOCALPART_REGEX = "([\\u0021-\\u0039]|[\\u003B-\\u007E])+";
 // https://github.com/johno/domain-regex/blob/8a6984c8fa1fe8481a4b99be0fa7f2a01ee17517/index.js
 const DOMAIN_REGEX = "(\\b((?=[a-z0-9-]{1,63}\\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,63}\\b)";
 // https://stackoverflow.com/a/5284410
@@ -52,7 +51,7 @@ export class MentionFlood implements IProtection {
     private mention: RegExp;
 
     constructor() {
-        this.mention = new RegExp(`@(${LOCALPART_REGEX}|${HISTORIC_LOCALPART_REGEX}):(${DOMAIN_REGEX}|${IPV4_REGEX}|${IPV6_REGEX})${PORT_REGEX}`, "gi");
+        this.mention = new RegExp(`@${LOCALPART_REGEX}:(${DOMAIN_REGEX}|${IPV4_REGEX}|${IPV6_REGEX})${PORT_REGEX}`, "gi");
     }
 
     public get name(): string {

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -20,7 +20,7 @@ import { Mjolnir } from "../Mjolnir";
 import { LogLevel, LogService } from "matrix-bot-sdk";
 import { logMessage } from "../LogProxy";
 import config from "../config";
-import { isTrueJoinEvent } from "../utils";
+import { htmlEscape, isTrueJoinEvent } from "../utils";
 import { BooleanProtectionSetting, NumberProtectionSetting, StringProtectionSetting } from "./ProtectionSettings";
 
 const DEFAULT_MINUTES_BEFORE_TRUSTING = 20;
@@ -72,7 +72,7 @@ export class MentionFlood implements IProtection {
                 if (isTrueJoinEvent(event)) {
                     const now = new Date();
                     this.justJoined.get(roomId)?.set(event['state_key'], now);
-                    LogService.info("MentionFlood", `${event['state_key']} joined ${roomId} at ${now.toDateString()}`);
+                    LogService.info("MentionFlood", `${htmlEscape(event['event_id'])} joined ${roomId} at ${now.toDateString()}`);
                 } else if (content['membership'] === 'leave' || content['membership'] === 'ban') {
                     this.justJoined.get(roomId)?.delete(event['sender']);
                 }
@@ -93,7 +93,7 @@ export class MentionFlood implements IProtection {
                     const now = new Date();
                     if (now.valueOf() - joinTime.valueOf() > minsBeforeTrusting * 60 * 1000) {
                         this.justJoined.get(roomId)?.delete(event['sender']); // Remove the user
-                        LogService.info("MentionFlood", `${event['sender']} is no longer considered suspect`);
+                        LogService.info("MentionFlood", `${htmlEscape(event['event_id'])} is no longer considered suspect`);
                         return;
                     }
 
@@ -111,29 +111,29 @@ export class MentionFlood implements IProtection {
                 const action = this.settings.action.value !== "" ? this.settings.action.value : DEFAULT_ACTION;
                 switch (action) {
                     case "ban": {
-                        await logMessage(LogLevel.WARN, "MentionFlood", `Banning ${event['sender']} for mention flood violation in ${roomId}.`);
+                        await logMessage(LogLevel.WARN, "MentionFlood", `Banning ${htmlEscape(event['event_id'])} for mention flood violation in ${roomId}.`);
                         if (!config.noop) {
                             await mjolnir.client.banUser(event['sender'], roomId, "Mention Flood violation");
                         } else {
-                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to ban ${event['sender']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to ban ${htmlEscape(event['event_id'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
                         }
                         break;
                     }
                     case "kick": {
-                        await logMessage(LogLevel.WARN, "MentionFlood", `Kicking ${event['sender']} for mention flood violation in ${roomId}.`);
+                        await logMessage(LogLevel.WARN, "MentionFlood", `Kicking ${htmlEscape(event['event_id'])} for mention flood violation in ${roomId}.`);
                         if (!config.noop) {
                             await mjolnir.client.kickUser(event['sender'], roomId, "Mention Flood violation");
                         } else {
-                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to kick ${event['sender']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to kick ${htmlEscape(event['event_id'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
                         }
                         break;
                     }
                     case "warn": {
-                        await logMessage(LogLevel.WARN, "MentionFlood", `Warning ${event['sender']} for mention flood violation in ${roomId}.`);
+                        await logMessage(LogLevel.WARN, "MentionFlood", `Warning ${htmlEscape(event['event_id'])} for mention flood violation in ${roomId}.`);
                         if (!config.noop) {
                             // await mjolnir.client.banUser(event['sender'], roomId, "Mention Flood violation");
                         } else {
-                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to warn ${event['sender']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to warn ${htmlEscape(event['event_id'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
                         }
                         break;
                     }
@@ -144,7 +144,7 @@ export class MentionFlood implements IProtection {
                 if (!config.noop && this.settings.redact.value) {
                     await mjolnir.client.redactEvent(roomId, event['event_id'], "spam");
                 } else {
-                    await logMessage(LogLevel.WARN, "MentionFlood", `Tried to redact ${event['event_id']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                    await logMessage(LogLevel.WARN, "MentionFlood", `Tried to redact ${htmlEscape(event['event_id'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
                 }
             }
         }

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -83,7 +83,7 @@ export class MentionFlood implements IProtection {
         }
 
         if (event['type'] === 'm.room.message') {
-            const message = content['body'] || "";
+            const message: string = content['formatted_body'] || content['body'] || "";
 
             // Check conditions first
             if (minsBeforeTrusting > 0) {
@@ -108,7 +108,7 @@ export class MentionFlood implements IProtection {
 
             // Perform the test
             const maxMentionsPerMessage = this.settings.maxMentionsPerMessage.value;
-            if (message && message.match(this.mention).length > maxMentionsPerMessage) {
+            if (message && (message.match(this.mention)?.length || 0) > maxMentionsPerMessage) {
                 const action = this.settings.action.value !== "" ? this.settings.action.value : DEFAULT_ACTION;
                 switch (action) {
                     case "ban": {

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -21,7 +21,7 @@ import { LogLevel, LogService } from "matrix-bot-sdk";
 import { logMessage } from "../LogProxy";
 import config from "../config";
 import { htmlEscape, isTrueJoinEvent } from "../utils";
-import { BooleanProtectionSetting, NumberProtectionSetting, StringProtectionSetting } from "./ProtectionSettings";
+import { BooleanProtectionSetting, NumberProtectionSetting, OptionListProtectionSetting } from "./ProtectionSettings";
 
 const DEFAULT_MINUTES_BEFORE_TRUSTING = 20;
 const DEFAULT_MAX_MENTIONS_PER_MESSAGE = 20;
@@ -44,7 +44,7 @@ export class MentionFlood extends Protection {
         minutesBeforeTrusting: new NumberProtectionSetting(DEFAULT_MINUTES_BEFORE_TRUSTING),
         maxMentionsPerMessage: new NumberProtectionSetting(DEFAULT_MAX_MENTIONS_PER_MESSAGE),
         redact: new BooleanProtectionSetting(DEFAULT_REDACT),
-        action: new StringProtectionSetting()
+        action: new OptionListProtectionSetting(["ban", "kick", "warn"])
     };
 
     private justJoined: Map<string, Map<string, Date>> = new Map<string, Map<string, Date>>();

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -20,9 +20,9 @@ import { Mjolnir } from "../Mjolnir";
 import { LogLevel, LogService } from "matrix-bot-sdk";
 import config from "../config";
 import { htmlEscape, isTrueJoinEvent } from "../utils";
-import { BooleanProtectionSetting, NumberProtectionSetting, OptionListProtectionSetting } from "./ProtectionSettings";
+import { BooleanProtectionSetting, DurationMSProtectionSetting, NumberProtectionSetting, OptionListProtectionSetting } from "./ProtectionSettings";
 
-const DEFAULT_MINUTES_BEFORE_TRUSTING = 20;
+const DEFAULT_MINUTES_BEFORE_TRUSTING = 20 * 60 * 1000;
 const DEFAULT_MAX_MENTIONS_PER_MESSAGE = 20;
 const DEFAULT_REDACT = true;
 const DEFAULT_ACTION = "ban";
@@ -40,9 +40,13 @@ const PORT_REGEX = "(:[0-9]+)?";
 export class MentionFlood extends Protection {
 
     settings = {
-        minutesBeforeTrusting: new NumberProtectionSetting(DEFAULT_MINUTES_BEFORE_TRUSTING),
+        // Time in which this protection takes action on users
+        minutesBeforeTrusting: new DurationMSProtectionSetting(DEFAULT_MINUTES_BEFORE_TRUSTING),
+        // The minimum amount of mentions for this protection to take action
         maxMentionsPerMessage: new NumberProtectionSetting(DEFAULT_MAX_MENTIONS_PER_MESSAGE),
+        // Defines if messages shall also get directly redacted or not
         redact: new BooleanProtectionSetting(DEFAULT_REDACT),
+        // The action that is supposed to get taken
         action: new OptionListProtectionSetting(["ban", "kick", "warn"])
     };
 

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -29,6 +29,7 @@ const DEFAULT_REDACT = true;
 const DEFAULT_ACTION = "ban";
 
 const LOCALPART_REGEX = "[0-9a-z-.=_/]+";
+const HISTORIC_LOCALPART_REGEX = "([\u0021-\u0039]|[\u003B-\u007E])+";
 // https://github.com/johno/domain-regex/blob/8a6984c8fa1fe8481a4b99be0fa7f2a01ee17517/index.js
 const DOMAIN_REGEX = "(\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b)";
 // https://stackoverflow.com/a/5284410
@@ -51,7 +52,7 @@ export class MentionFlood implements IProtection {
     private mention: RegExp;
 
     constructor() {
-        this.mention = new RegExp(`@${LOCALPART_REGEX}:(${DOMAIN_REGEX}|${IPV4_REGEX}|${IPV6_REGEX})${PORT_REGEX}`, "g");
+        this.mention = new RegExp(`@(${LOCALPART_REGEX}|${HISTORIC_LOCALPART_REGEX}):(${DOMAIN_REGEX}|${IPV4_REGEX}|${IPV6_REGEX})${PORT_REGEX}`, "g");
     }
 
     public get name(): string {
@@ -82,7 +83,7 @@ export class MentionFlood implements IProtection {
         }
 
         if (event['type'] === 'm.room.message') {
-            const message = content['formatted_body'] || content['body'] || null;
+            const message = content['body'] || "";
 
             // Check conditions first
             if (minsBeforeTrusting > 0) {

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -130,12 +130,7 @@ export class MentionFlood implements IProtection {
                         break;
                     }
                     case "warn": {
-                        await logMessage(LogLevel.WARN, "MentionFlood", `Warning ${htmlEscape(event['sender'])} for mention flood violation in ${roomId}.`);
-                        if (!config.noop) {
-                            // await mjolnir.client.banUser(event['sender'], roomId, "Mention Flood violation");
-                        } else {
-                            await logMessage(LogLevel.WARN, "MentionFlood", `Tried to warn ${htmlEscape(event['sender'])} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
-                        }
+                        await logMessage(LogLevel.WARN, "MentionFlood", `${htmlEscape(event['sender'])} triggered the mention flood protection in ${roomId}.`);
                         break;
                     }
                 }

--- a/src/protections/ProtectionSettings.ts
+++ b/src/protections/ProtectionSettings.ts
@@ -196,7 +196,13 @@ export class BooleanProtectionSetting extends AbstractProtectionSetting<boolean,
     }
 
     fromString(data: string) {
-        return data.toLowerCase() === "true" ? true : false;
+        if (data.toLowerCase() === "true") {
+            return true;
+        } else if (data.toLowerCase() === "false") {
+            return false;
+        } else {
+            return undefined;
+        }
     }
     validate = (data: boolean): boolean => true;
 }

--- a/src/protections/ProtectionSettings.ts
+++ b/src/protections/ProtectionSettings.ts
@@ -25,7 +25,7 @@ parseDuration["weeks"] = parseDuration["week"] = parseDuration["wk"];
 parseDuration["months"] = parseDuration["month"];
 parseDuration["years"] = parseDuration["year"];
 
-export class ProtectionSettingValidationError extends Error {};
+export class ProtectionSettingValidationError extends Error { };
 
 /*
  * @param TChange Type for individual pieces of data (e.g. `string`)
@@ -106,7 +106,7 @@ export class StringListProtectionSetting extends AbstractProtectionListSetting<s
     }
     removeValue(data: string): string[] {
         this.emit("remove", data);
-        this.value =  this.value.filter(i => i !== data);
+        this.value = this.value.filter(i => i !== data);
         return this.value;
     }
 }
@@ -166,9 +166,9 @@ export class NumberProtectionSetting extends AbstractProtectionSetting<number, n
  */
 export class DurationMSProtectionSetting extends AbstractProtectionSetting<number, number> {
     constructor(
-            defaultValue: number,
-            public readonly minMS: number|undefined = undefined,
-            public readonly maxMS: number|undefined = undefined
+        defaultValue: number,
+        public readonly minMS: number | undefined = undefined,
+        public readonly maxMS: number | undefined = undefined
     ) {
         super();
         this.setValue(defaultValue);
@@ -181,7 +181,7 @@ export class DurationMSProtectionSetting extends AbstractProtectionSetting<numbe
     validate(data: number) {
         return (!isNaN(data)
             && (this.minMS === undefined || this.minMS <= data)
-            && (this.maxMS === undefined || data <= this.maxMS))
+            && (this.maxMS === undefined || data <= this.maxMS));
     }
 }
 

--- a/src/protections/ProtectionSettings.ts
+++ b/src/protections/ProtectionSettings.ts
@@ -185,8 +185,8 @@ export class DurationMSProtectionSetting extends AbstractProtectionSetting<numbe
     }
 }
 
-
-
+// A setting that only can be true or false.
+// Returns undefined if anything else is set.
 export class BooleanProtectionSetting extends AbstractProtectionSetting<boolean, boolean> {
     constructor(
         defaultValue: boolean
@@ -195,6 +195,7 @@ export class BooleanProtectionSetting extends AbstractProtectionSetting<boolean,
         this.setValue(defaultValue);
     }
 
+    // We return undefined for anything other than "true" or "false"
     fromString(data: string) {
         if (data.toLowerCase() === "true") {
             return true;
@@ -204,5 +205,23 @@ export class BooleanProtectionSetting extends AbstractProtectionSetting<boolean,
             return undefined;
         }
     }
+
+    // This is already handled in setProtectionSettings due to the types
     validate = (data: boolean): boolean => true;
+}
+
+
+// A list of strings that match the allowed values
+export class OptionListProtectionSetting extends AbstractProtectionSetting<string, string> {
+    constructor(private allowedValues: string[]) {
+        super();
+    }
+
+    // We dont need to convert the string
+    fromString(data: string) {
+        return data;
+    }
+
+    // validates if data is in the allowedValues
+    validate = (data: string) => this.allowedValues.includes(data);
 }

--- a/src/protections/ProtectionSettings.ts
+++ b/src/protections/ProtectionSettings.ts
@@ -33,7 +33,7 @@ export class ProtectionSettingValidationError extends Error {};
  */
 export class AbstractProtectionSetting<TChange, TValue> extends EventEmitter {
     // the current value of this setting
-    value: TValue
+    value: TValue;
 
     /*
      * Deserialise a value for this setting type from a string
@@ -134,13 +134,13 @@ export class MXIDListProtectionSetting extends StringListProtectionSetting {
 }
 
 export class NumberProtectionSetting extends AbstractProtectionSetting<number, number> {
-    min: number|undefined;
-    max: number|undefined;
+    min: number | undefined;
+    max: number | undefined;
 
     constructor(
-            defaultValue: number,
-            min: number|undefined = undefined,
-            max: number|undefined = undefined
+        defaultValue: number,
+        min: number | undefined = undefined,
+        max: number | undefined = undefined
     ) {
         super();
         this.setValue(defaultValue);
@@ -155,7 +155,7 @@ export class NumberProtectionSetting extends AbstractProtectionSetting<number, n
     validate(data: number) {
         return (!isNaN(data)
             && (this.min === undefined || this.min <= data)
-            && (this.max === undefined || data <= this.max))
+            && (this.max === undefined || data <= this.max));
     }
 }
 
@@ -183,4 +183,20 @@ export class DurationMSProtectionSetting extends AbstractProtectionSetting<numbe
             && (this.minMS === undefined || this.minMS <= data)
             && (this.maxMS === undefined || data <= this.maxMS))
     }
+}
+
+
+
+export class BooleanProtectionSetting extends AbstractProtectionSetting<boolean, boolean> {
+    constructor(
+        defaultValue: boolean
+    ) {
+        super();
+        this.setValue(defaultValue);
+    }
+
+    fromString(data: string) {
+        return data.toLowerCase() === "true" ? true : false;
+    }
+    validate = (data: boolean): boolean => true;
 }

--- a/src/protections/protections.ts
+++ b/src/protections/protections.ts
@@ -22,6 +22,7 @@ import { WordList } from "./WordList";
 import { MessageIsVoice } from "./MessageIsVoice";
 import { MessageIsMedia } from "./MessageIsMedia";
 import { TrustedReporters } from "./TrustedReporters";
+import { MentionFlood } from "./MentionFlood";
 
 export const PROTECTIONS: Protection[] = [
     new FirstMessageIsImage(),
@@ -31,4 +32,5 @@ export const PROTECTIONS: Protection[] = [
     new MessageIsMedia(),
     new TrustedReporters(),
     new DetectFederationLag(),
+    new MentionFlood(),
 ];

--- a/test/integration/protections/MentionFloodTest.ts
+++ b/test/integration/protections/MentionFloodTest.ts
@@ -1,0 +1,187 @@
+import { LogService } from "matrix-bot-sdk";
+import config from "../../../src/config";
+import { newTestUser } from "../clientHelper";
+import { getFirstReaction, getFirstReply } from "../commands/commandUtils";
+import { strict as assert } from "assert";
+import { checkMembershipChange, getFirstMessage } from "./protectionUtils";
+
+// Produces generic "spam" events.
+const produceRandomSpam = async (userA, targetRoom) => {
+    // Generate random "spam"
+    for (let i = 0; i < 10000; i++) {
+        let randomMessageThatIsSpammy = (Math.random() + 1).toString(36).substring(7);
+        await userA.sendMessage(targetRoom, { msgtype: 'm.text', body: `${randomMessageThatIsSpammy}` });
+    }
+};
+
+describe("Test: MentionFlood protection", function () {
+    afterEach(function () {
+        this.moderator?.stop();
+        this.userA?.stop();
+    });
+
+    // Tests if enabling the protection works
+    it('Enabling the MentionFlood protection works', async function () {
+        // Create users
+        const mjolnir = config.RUNTIME.client!;
+        const moderator = await newTestUser({ name: { contains: "moderator" } });
+
+        this.moderator = moderator;
+
+        // Join managementroom
+        await moderator.joinRoom(config.managementRoom);
+        LogService.debug("MentionFloodTest", `Joining managementRoom: ${config.managementRoom}`);
+
+        try {
+            await moderator.start();
+            await getFirstReaction(mjolnir, this.mjolnir.managementRoomId, '✅', async () => {
+                LogService.debug("MentionFloodTest", `Enabling MentionFlood protection next`);
+                return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir enable MentionFlood` });
+            });
+        } finally {
+            await moderator.stop();
+        }
+
+    });
+
+    // Tests that regular spam isnt triggering this
+    it('Regular flooding should not be detected by MentionFlood Protection', async function () {
+        // Create users
+        const mjolnir = config.RUNTIME.client!;
+        const mjolnirUserId = await mjolnir.getUserId();
+        const moderator = await newTestUser({ name: { contains: "moderator" } });
+        const userA = await newTestUser({ name: { contains: "a" } });
+
+        this.moderator = moderator;
+        this.userA = userA;
+
+        // Join managementroom and setup target room
+        await moderator.joinRoom(config.managementRoom);
+        LogService.debug("MentionFloodTest", `Joining managementRoom: ${config.managementRoom}`);
+        let targetRoom = await moderator.createRoom({ invite: [mjolnirUserId] });
+        LogService.debug("MentionFloodTest", `moderator creating targetRoom: ${targetRoom}; and inviting ${mjolnirUserId}`);
+        await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir rooms add ${targetRoom}` });
+        LogService.debug("MentionFloodTest", `Adding targetRoom: ${targetRoom}`);
+        try {
+            await moderator.start();
+            await userA.start();
+            await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir enable MentionFlood` });
+            LogService.debug("MentionFloodTest", `Enabling MentionFlood protection`);
+
+            // Idea here is that we send spam to the room and then get the mjolnir status as a test case.
+            // If everything goes well we should only see the status in the management room and no spam warnings.
+            const statusResp = await getFirstMessage(this.mjolnir, this.mjolnir.managementRoom, async () => {
+                await produceRandomSpam(userA, targetRoom);
+                return await moderator.sendMessage(this.mjolnir.managementRoom, { msgtype: 'm.text', body: `!mjolnir` });
+            });
+            assert.equal(statusResp.content.body.includes('Protected rooms: 1'), true, 'unexpected message from mjolnir while fake spamming');
+        } finally {
+            await moderator.stop();
+            await userA.stop();
+        }
+    });
+
+    // Tests that normal mentions do not trigger the protection
+    it('Regular mentions should not be detected by MentionFlood Protection', async function () {
+        // Create users
+        const mjolnir = config.RUNTIME.client!;
+        const mjolnirUserId = await mjolnir.getUserId();
+        const moderator = await newTestUser({ name: { contains: "moderator" } });
+        const userA = await newTestUser({ name: { contains: "a" } });
+
+        this.moderator = moderator;
+        this.userA = userA;
+
+        // Join managmentroom and setup targget room
+        await moderator.joinRoom(config.managementRoom);
+        LogService.debug("MentionFloodTest", `Joining managementRoom: ${config.managementRoom}`);
+        let targetRoom = await moderator.createRoom({ invite: [mjolnirUserId] });
+        LogService.debug("MentionFloodTest", `moderator creating targetRoom: ${targetRoom}; and inviting ${mjolnirUserId}`);
+        await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir rooms add ${targetRoom}` });
+        LogService.debug("MentionFloodTest", `Adding targetRoom: ${targetRoom}`);
+
+        await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir enable MentionFlood` });
+        LogService.debug("MentionFloodTest", `Enabling MentionFlood protection`);
+
+
+        await moderator.start();
+        await userA.start();
+
+        // Mention a user (a non existent is fine as we dont check for existence of users)
+        // We use the mjolnir status as a test case. We shouldnt see any other messages happen.
+        const statusResp = await getFirstMessage(this.mjolnir, this.mjolnir.managementRoom, async () => {
+            await userA.sendMessage(targetRoom, { msgtype: 'm.text', body: `@random:test.server Test Mention` });
+            return await moderator.sendMessage(this.mjolnir.managementRoom, { msgtype: 'm.text', body: `!mjolnir` });
+        });
+        assert.equal(statusResp.content.body.includes('Protected rooms: 1'), true, 'unexpected message from mjolnir while fake spamming');
+    });
+
+    // Tests that html mentions over the limit should be reacted upon
+    it('HTML mentions (pills) over the limit should be detected by MentionFlood Protection', async function () {
+        // Create users
+        const mjolnir = config.RUNTIME.client!;
+        const mjolnirUserId = await mjolnir.getUserId();
+        const moderator = await newTestUser({ name: { contains: "moderator" } });
+        const userA = await newTestUser({ name: { contains: "a" } });
+
+        this.moderator = moderator;
+        this.userA = userA;
+
+        // Join managmentroom and setup targget room
+        await moderator.joinRoom(config.managementRoom);
+        LogService.debug("MentionFloodTest", `Joining managementRoom: ${config.managementRoom}`);
+        let targetRoom = await moderator.createRoom({ invite: [mjolnirUserId] });
+        LogService.debug("MentionFloodTest", `moderator creating targetRoom: ${targetRoom}; and inviting ${mjolnirUserId}`);
+        await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir rooms add ${targetRoom}` });
+        LogService.debug("MentionFloodTest", `Adding targetRoom: ${targetRoom}`);
+
+        let textMessage = "";
+        let htmlMessage = "<p>";
+        for (let i = 0; i < 30; i++) {
+            let randomUsername = (Math.random() + 1).toString(36).substring(7);
+            textMessage = `${textMessage} ${randomUsername}`;
+            htmlMessage = `${htmlMessage} <del><a href=\"https://matrix.to/#/@${randomUsername}:test.server\">${randomUsername}</a>`;
+        }
+        htmlMessage = `${htmlMessage}</p>`;
+        const actionTakenResponse = await getFirstReply(mjolnir, this.mjolnir.managementRoom, async () => {
+            return await userA.sendMessage(targetRoom, { msgtype: 'm.text', body: textMessage, format: "org.matrix.custom.html", formatted_body: htmlMessage });
+        });
+        assert.equal(actionTakenResponse.content.body.includes(`Banning ${await userA.getUserId()} for mention flood violation in ${targetRoom}.`), true, 'protection did not log protecting against mention spam.');
+    });
+
+    // Tests that text mentions over the limit should be reacted upon.
+    // This is intentionally a mention with mxid as this is based on real world spam from the past.
+    it('Text mentions (non pills) over the limit should be detected by MentionFlood Protection (if it is a mxid)', async function () {
+        // Create users
+        const mjolnir = config.RUNTIME.client!;
+        const mjolnirUserId = await mjolnir.getUserId();
+        const moderator = await newTestUser({ name: { contains: "moderator" } });
+        const userA = await newTestUser({ name: { contains: "a" } });
+
+        this.moderator = moderator;
+        this.userA = userA;
+
+        // Join managmentroom and setup targget room
+        await moderator.joinRoom(config.managementRoom);
+        LogService.debug("MentionFloodTest", `Joining managementRoom: ${config.managementRoom}`);
+        let targetRoom = await moderator.createRoom({ invite: [mjolnirUserId] });
+        LogService.debug("MentionFloodTest", `moderator creating targetRoom: ${targetRoom}; and inviting ${mjolnirUserId}`);
+        await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir rooms add ${targetRoom}` });
+        LogService.debug("MentionFloodTest", `Adding targetRoom: ${targetRoom}`);
+
+        await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir enable MentionFlood` });
+        LogService.debug("MentionFloodTest", `Enabling MentionFlood protection`);
+
+        let textMessage = "";
+        for (let i = 0; i < 30; i++) {
+            let randomUsername = (Math.random() + 1).toString(36).substring(7);
+            textMessage = `${textMessage} @${randomUsername}:test.server`;
+        }
+        const actionTakenResponse = await getFirstReply(mjolnir, this.mjolnir.managementRoom, async () => {
+            return await userA.sendMessage(targetRoom, { msgtype: 'm.text', body: textMessage });
+        });
+        assert.equal(actionTakenResponse.content.body.includes(`Banning ${await userA.getUserId()} for mention flood violation in ${targetRoom}.`), true, 'protection did not log protecting against mention spam.');
+        const membershipResp = await checkMembershipChange(mjolnir, targetRoom, await userA.getUserId(), "ban");
+        assert.equal(membershipResp, true, 'user was not banned from target room');
+    });
+});

--- a/test/integration/protections/protectionUtils.ts
+++ b/test/integration/protections/protectionUtils.ts
@@ -1,0 +1,85 @@
+import { MatrixClient } from "matrix-bot-sdk";
+
+/**
+ * Returns a promise that resolves to the first event while sending events.
+ * @param client A MatrixClient that is already in the targetRoom. We will use it to listen for the event produced by targetEventThunk.
+ * This function assumes that the start() has already been called on the client.
+ * @param targetRoom The room to listen for the reply in.
+ * @param produceEvents A function that produces an events when called.
+ * @returns The first event.
+ */
+export async function getFirstMessage(client: MatrixClient, targetRoom: string, produceEvents: () => Promise<any>): Promise<any> {
+    let reactionEvents = [];
+    const addEvent = function (roomId, event) {
+        if (roomId !== targetRoom) return;
+        if (event.type !== 'm.room.message') return;
+        reactionEvents.push(event);
+    };
+    let targetCb;
+    try {
+        client.on('room.event', addEvent);
+        await produceEvents();
+        for (let event of reactionEvents) {
+            return event;
+        }
+        return await new Promise(resolve => {
+            targetCb = function (roomId, event) {
+                if (roomId !== targetRoom) return;
+                if (event.type !== 'm.room.message') return;
+                resolve(event);
+            };
+            client.on('room.event', targetCb);
+        });
+    } finally {
+        client.removeListener('room.event', addEvent);
+        if (targetCb) {
+            client.removeListener('room.event', targetCb);
+        }
+    }
+}
+
+/**
+ * Returns true if the user got changed to the wanted membership type.
+ * @param client A MatrixClient that is already in the targetRoom. We will use it to listen for the event produced by targetEventThunk.
+ * This function assumes that the start() has already been called on the client.
+ * @param targetRoom The room to listen for the reply in.
+ * @param userId The user that should get checked for.
+ * @param membership The membership type that the user should get.
+ * @returns The first event.
+ */
+export async function checkMembershipChange(client: MatrixClient, targetRoom: string, userId: string, membership: string): Promise<boolean> {
+    let membershipEvents = [];
+    const addEvent = function (roomId, event) {
+        if (roomId !== targetRoom) return;
+        if (event.type !== 'm.room.member') return;
+        membershipEvents.push(event);
+    };
+    let targetCb;
+    try {
+        client.on('room.event', addEvent);
+        for (let event of membershipEvents) {
+            if (event.state_key == userId && event.content.membership == membership) {
+                return true;
+            } else if (event.state_key == userId && event.content.membership != membership) {
+                return false;
+            }
+        }
+        return await new Promise(resolve => {
+            targetCb = function (roomId, event) {
+                if (roomId !== targetRoom) return;
+                if (event.type !== 'm.room.member') return;
+                if (event.state_key == userId && event.content.membership == membership) {
+                    resolve(true);
+                } else if (event.state_key == userId && event.content.membership != membership) {
+                    resolve(false);
+                }
+            };
+            client.on('room.event', targetCb);
+        });
+    } finally {
+        client.removeListener('room.event', addEvent);
+        if (targetCb) {
+            client.removeListener('room.event', targetCb);
+        }
+    }
+}


### PR DESCRIPTION
This basically tries to solve the current way of spam.

This is an adapted wordfilter protection. At the time of writing, this is not tested anywhere.

It only matches mxid based mentions currently. Not other mentions per default push rules.

## TODO

- [x] Finish the warning branch
- [x] Test it (I have a docker of this branch at `coreharbor.kubernetes.midnightthoughts.space/matrixdotorg/mjolnir:mentionflood-protection` )

![image](https://user-images.githubusercontent.com/1374914/152682102-43f677f8-53bb-410e-af09-d8dbc039beff.png)
![image](https://user-images.githubusercontent.com/1374914/152682109-f4e66f28-11e9-4fde-895b-d79858279c91.png)


Signed-off-by: Marcel Radzio <mtrnord[at]nordgedanken.dev>