### PR TITLE
Fix traceback on Abuse Report.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ typings/
 
 # Python packing directories.
 mjolnir.egg-info/
+
+# Visual Studio data
+.vs

--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -234,7 +234,7 @@ export class Mjolnir {
         // Setup Web APIs
         console.log("Creating Web APIs");
         const reportManager = new ReportManager(this);
-        reportManager.on("report.new", this.handleReport.bind(this);
+        reportManager.on("report.new", this.handleReport.bind(this));
         this.webapis = new WebAPIs(reportManager, this.ruleServer);
     }
 

--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -234,7 +234,7 @@ export class Mjolnir {
         // Setup Web APIs
         console.log("Creating Web APIs");
         const reportManager = new ReportManager(this);
-        reportManager.on("report.new", this.handleReport);
+        reportManager.on("report.new", this.handleReport.bind(this);
         this.webapis = new WebAPIs(reportManager, this.ruleServer);
     }
 
@@ -1023,7 +1023,7 @@ export class Mjolnir {
         return await this.eventRedactionQueue.process(this, roomId);
     }
 
-    private async handleReport(e: any) {
+    private async handleReport(e: { mjolnir: Mjolnir, roomId: string, reporterId: string, event: any, reason?: string }) {
         for (const protection of e.mjolnir.enabledProtections) {
             await protection.handleReport(e.mjolnir, e.roomId, e.reporterId, e.event, e.reason);
         }

--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -1023,9 +1023,9 @@ export class Mjolnir {
         return await this.eventRedactionQueue.process(this, roomId);
     }
 
-    private async handleReport(e: { mjolnir: Mjolnir, roomId: string, reporterId: string, event: any, reason?: string }) {
-        for (const protection of e.mjolnir.enabledProtections) {
-            await protection.handleReport(e.mjolnir, e.roomId, e.reporterId, e.event, e.reason);
+    private async handleReport(e: { roomId: string, reporterId: string, event: any, reason?: string }) {
+        for (const protection of this.enabledProtections) {
+            await protection.handleReport(this, e.roomId, e.reporterId, e.event, e.reason);
         }
     }
 }

--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -1023,9 +1023,9 @@ export class Mjolnir {
         return await this.eventRedactionQueue.process(this, roomId);
     }
 
-    private async handleReport(roomId: string, reporterId: string, event: any, reason?: string) {
-        for (const protection of this.enabledProtections) {
-            await protection.handleReport(this, roomId, reporterId, event, reason);
+    private async handleReport(e: any) {
+        for (const protection of e.mjolnir.enabledProtections) {
+            await protection.handleReport(e.mjolnir, e.roomId, e.reporterId, e.event, e.reason);
         }
     }
 }

--- a/src/protections/IProtection.ts
+++ b/src/protections/IProtection.ts
@@ -34,7 +34,7 @@ export interface IProtection {
      */
     handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any>;
     /*
-     * Handle a single reported event from a protecte room, to decide if we
+     * Handle a single reported event from a protected room, to decide if we
      * need to respond to it
      */
     handleReport(mjolnir: Mjolnir, roomId: string, reporterId: string, reason: string, event: any): Promise<any>;

--- a/src/report/ReportManager.ts
+++ b/src/report/ReportManager.ts
@@ -113,7 +113,7 @@ export class ReportManager extends EventEmitter {
      * @param reason A reason provided by the reporter.
      */
     public async handleServerAbuseReport({ roomId, reporterId, event, reason }: { roomId: string, reporterId: string, event: any, reason?: string }) {
-        this.emit("report.new", { roomId: roomId, reporterId: reporterId, event: event, reason: reason });
+        this.emit("report.new", { mjolnir: this.mjolnir, roomId: roomId, reporterId: reporterId, event: event, reason: reason });
         return this.displayManager.displayReportAndUI({ kind: Kind.SERVER_ABUSE_REPORT, event, reporterId, reason, moderationRoomId: this.mjolnir.managementRoomId });
     }
 

--- a/src/report/ReportManager.ts
+++ b/src/report/ReportManager.ts
@@ -113,7 +113,7 @@ export class ReportManager extends EventEmitter {
      * @param reason A reason provided by the reporter.
      */
     public async handleServerAbuseReport({ roomId, reporterId, event, reason }: { roomId: string, reporterId: string, event: any, reason?: string }) {
-        this.emit("report.new", { mjolnir: this.mjolnir, roomId: roomId, reporterId: reporterId, event: event, reason: reason });
+        this.emit("report.new", { roomId: roomId, reporterId: reporterId, event: event, reason: reason });
         return this.displayManager.displayReportAndUI({ kind: Kind.SERVER_ABUSE_REPORT, event, reporterId, reason, moderationRoomId: this.mjolnir.managementRoomId });
     }
 


### PR DESCRIPTION
The callback function at https://github.com/matrix-org/mjolnir/blob/main/src/Mjolnir.ts#L1026 receives the event packed object as single argument and not all the arguments 'emselves. Also to avoid any possible scope issues it's best to pass the Mjolnir object itself to the CB.