### PR TITLE
Fix block_usernames config option

### DIFF
--- a/synapse_antispam/mjolnir/antispam.py
+++ b/synapse_antispam/mjolnir/antispam.py
@@ -121,7 +121,9 @@ class AntiSpam(object):
 
     def check_username_for_spam(self, user_profile):
         if not self.block_usernames:
-            return True  # allowed (we aren't blocking based on usernames)
+            # /!\ NB: unlike other checks, where `True` means allowed,
+            # here `True` means "this user is a spammer".
+            return False  # allowed (we aren't blocking based on usernames)
 
         # Check whether the user ID or display name matches any of the banned
         # patterns.


### PR DESCRIPTION
Fixes #244.

We've made the same (unfortunate) mistake before in https://github.com/matrix-org/message_limit/commit/a6e4709a843daa30cce5f7a1c7d1dbc96753d221; see also https://github.com/matrix-org/synapse/commit/73fc4887834b33afaf23ff48a68772f8ef9b924c.