### PR TITLE
Change antispam Python module verison with mjolnir version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "start:dev": "yarn build && node --async-stack-traces lib/index.js",
     "test": "ts-mocha --project ./tsconfig.json test/commands/**/*.ts",
     "test:integration": "NODE_ENV=harness ts-mocha --async-stack-traces --require test/integration/fixtures.ts --project ./tsconfig.json \"test/integration/**/*Test.ts\"",
-    "test:manual": "NODE_ENV=harness ts-node test/integration/manualLaunchScript.ts"
+    "test:manual": "NODE_ENV=harness ts-node test/integration/manualLaunchScript.ts",
+    "version": "sed -i 's/[0-9]\\.[0-9]\\.[0-9]/'$npm_package_version'/g' synapse_antispam/setup.py && git add synapse_antispam/setup.py && cat synapse_antispam/setup.py"
   },
   "devDependencies": {
     "@types/config": "0.0.41",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "ts-mocha --project ./tsconfig.json test/commands/**/*.ts",
     "test:integration": "NODE_ENV=harness ts-mocha --async-stack-traces --require test/integration/fixtures.ts --project ./tsconfig.json \"test/integration/**/*Test.ts\"",
     "test:manual": "NODE_ENV=harness ts-node test/integration/manualLaunchScript.ts",
-    "version": "sed -i 's/[0-9]\\.[0-9]\\.[0-9]/'$npm_package_version'/g' synapse_antispam/setup.py && git add synapse_antispam/setup.py && cat synapse_antispam/setup.py"
+    "version": "sed -i '/# version automated/s/[0-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*/'$npm_package_version'/' synapse_antispam/setup.py && git add synapse_antispam/setup.py && cat synapse_antispam/setup.py"
   },
   "devDependencies": {
     "@types/config": "0.0.41",

--- a/synapse_antispam/setup.py
+++ b/synapse_antispam/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="mjolnir",
-    version="0.1.0",
+    version="0.1.0", # version automated in package.json - Do not edit this line, use `yarn version`.
     packages=find_packages(),
     description="Mjolnir Antispam",
     include_package_data=True,


### PR DESCRIPTION
The reason we want this is so that people do not forget to change the verison number in the synapse module.
The precedent is that the version number has been 0.1.0 since the begging until now.
While this solution does mean that there may be new version of the module where
nothing has actually changed, this is still better than not changing the version at all.
Another version scheme for the module would be inconsistent to
the git repository tags and that has the potential to cause much more confusion
than "blank" version bumps.
If this is a problem, then antispam must be extracted to another repository.

In order to test this, run `yarn version --patch` observe the changes with `git log` and `git diff HEAD~`,
then YOU MUST delete the tag with `git tag --delete vd.d.d` when you are finished.

https://classic.yarnpkg.com/en/docs/cli/version