### PR TITLE
Use github workflows to push dockerhub images+tags.

### DIFF
--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -1,0 +1,34 @@
+# Copied from https://github.com/matrix-org/matrix-bifrost/blob/develop/.github/workflows/docker-hub-latest.yml
+
+name: "Docker Hub - Latest"
+
+on:
+  push:
+
+env:
+  DOCKER_NAMESPACE: matrixdotorg
+  PLATFORMS: linux/amd64
+  # Only push if this is main, otherwise we just want to build
+  PUSH: ${{ github.ref == 'refs/heads/main' }}
+
+jobs:
+  docker-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: ${{ env.PUSH }}
+          tags: |
+            ${{ env.DOCKER_NAMESPACE }}/mjolnir:latest

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -1,0 +1,35 @@
+# Copied from https://github.com/matrix-org/matrix-bifrost/blob/develop/.github/workflows/docker-hub-release.yml
+
+name: "Docker Hub - Release"
+
+on:
+  release:
+    types: [published]
+
+env:
+  DOCKER_NAMESPACE: matrixdotorg
+  PLATFORMS: linux/amd64
+
+jobs:
+  docker-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Get release tag
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: |
+            ${{ env.DOCKER_NAMESPACE }}/mjolnir:${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
Currently the `latest` tag on dockerhub is out of sync as it was using docker hub's autobuild which matrix.org no longer supports. 

Here we use github actions to push and tag the images instead. 