### PR TITLE
Make startup failures more controlled and understandable.

### DIFF
--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -320,11 +320,12 @@ export class Mjolnir {
             try {
                 LogService.error("Mjolnir", "Error during startup:");
                 LogService.error("Mjolnir", extractRequestError(err));
+                this.stop();
                 await this.logMessage(LogLevel.ERROR, "Mjolnir@startup", "Startup failed due to error - see console");
+                throw err;
             } catch (e) {
-                // If we failed to handle the error, just crash
-                console.error(e);
-                process.exit(1);
+                LogService.error("Mjolnir", `Failed to report startup error to the management room: ${e}`);
+                throw err;
             }
         }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,9 +57,14 @@ if (config.health.healthz.enabled) {
         config.RUNTIME.client = client;
 
         bot = await Mjolnir.setupMjolnirFromConfig(client);
+    } catch (err) {
+        console.error(`Failed to setup mjolnir from the config ${config.dataPath}: ${err}`);
+        throw err;
+    }
+    try {
         await bot.start();
     } catch (err) {
-        bot?.logMessage(LogLevel.ERROR, "index", err);
-        process.exit(1);
+        console.error(`Mjolnir failed to start: ${err}`);
+        throw err;
     }
 })();


### PR DESCRIPTION
There is no reason to call process.exit() from `index.ts` or in `Mjolnir.start()` because

https://nodejs.org/api/process.html#warning-using-uncaughtexception-correctly

>The 'uncaughtException' event is emitted when an uncaught JavaScript exception bubbles all the way back to the event loop. By default, Node.js handles such exceptions by printing the stack trace to stderr and exiting with code 1, overriding any previously set process.exitCode. Adding a handler for the 'uncaughtException' event overrides this default behaviour.