### PR TITLE
Amend README.md for antispam config example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ modules:
       # these rooms.
       ban_lists:
          - "!roomid:example.org"
-      message_max_length:
+      #message_max_length:
          # Limit the characters in a message (event body) that a client can send in an event on this server.
          # By default there is no limit (beyond the the limit the spec enforces on event size).
          # Uncomment if you want messages to be limited to 510 characters.


### PR DESCRIPTION
Using the example as is will cause Synapse to not start with the following traceback:

```
Apr  3 09:52:37 akademeia matrix-synapse-worker_media_1[2922268]: 2022-04-03 09:52:37,038 - synapse.app._base - 242 - CRITICAL - sentinel - Error during startup
Apr  3 09:52:37 akademeia matrix-synapse-worker_media_1[2922268]: Traceback (most recent call last):
Apr  3 09:52:37 akademeia matrix-synapse-worker_media_1[2922268]:   File "/opt/venvs/matrix-synapse/lib/python3.8/site-packages/synapse/app/_base.py", line 227, in wrapper
Apr  3 09:52:37 akademeia matrix-synapse-worker_media_1[2922268]:     await cb(*args, **kwargs)
Apr  3 09:52:37 akademeia matrix-synapse-worker_media_1[2922268]:   File "/opt/venvs/matrix-synapse/lib/python3.8/site-packages/synapse/app/_base.py", line 438, in start
Apr  3 09:52:37 akademeia matrix-synapse-worker_media_1[2922268]:     m = module(config=config, api=module_api)
Apr  3 09:52:37 akademeia matrix-synapse-worker_media_1[2922268]:   File "/opt/venvs/matrix-synapse/lib/python3.8/site-packages/mjolnir/antispam.py", line 158, in __init__
Apr  3 09:52:37 akademeia matrix-synapse-worker_media_1[2922268]:     self.message_max_length = MessageMaxLength(config.get("message_max_length", {}), api)
Apr  3 09:52:37 akademeia matrix-synapse-worker_media_1[2922268]:   File "/opt/venvs/matrix-synapse/lib/python3.8/site-packages/mjolnir/message_max_length.py", line 28, in __init__
Apr  3 09:52:37 akademeia matrix-synapse-worker_media_1[2922268]:     self.threshold: Option[int] = config.get("threshold", None)
Apr  3 09:52:37 akademeia matrix-synapse-worker_media_1[2922268]: AttributeError: 'NoneType' object has no attribute 'get'
```

Leaving the whole message_max_length block commented fixes the issue.