### PR TITLE
Add Join Wave Short-Circuit Protection

### DIFF
--- a/src/protections/IProtection.ts
+++ b/src/protections/IProtection.ts
@@ -28,6 +28,7 @@ export abstract class Protection {
     abstract readonly name: string
     abstract readonly description: string;
     enabled = false;
+    readonly requiredStatePermissions: string[] = [];
     abstract settings: { [setting: string]: AbstractProtectionSetting<any, any> };
 
     /*

--- a/src/protections/JoinWaveShortCircuit.ts
+++ b/src/protections/JoinWaveShortCircuit.ts
@@ -68,11 +68,11 @@ export class JoinWaveShortCircuit extends Protection {
             return;
         }
 
-        const userState = event['content']['membership'];
-        const prevMembership = event['unsigned']?.['prev_content']?.['membership'] || "leave";
+        const newMembership = event['content']['membership'];
+        const prevMembership = event['unsigned']?.['prev_content']?.['membership'] || null;
 
         // We look at the previous membership to filter out profile changes
-        if (userState === 'join' && prevMembership !== "join") {
+        if (newMembership === 'join' && prevMembership !== "join") {
             // A new join, fallthrough
         } else {
             return;

--- a/src/protections/JoinWaveShortCircuit.ts
+++ b/src/protections/JoinWaveShortCircuit.ts
@@ -1,0 +1,131 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {Protection} from "./IProtection";
+import {Mjolnir} from "../Mjolnir";
+import {NumberProtectionSetting} from "./ProtectionSettings";
+import {LogLevel} from "matrix-bot-sdk";
+import config from "../config";
+
+export const DEFAULT_MAX_PER_HOUR = 50;
+const ONE_HOUR = 3600_000; // 1h in ms
+
+export class JoinWaveShortCircuit extends Protection {
+    requiredStatePermissions = ["m.room.join_rules"]
+
+    private joinBuckets: {
+        [roomId: string]: {
+            lastBucketStart: Date,
+            numberOfJoins: number,
+        }
+    } = {};
+
+    settings = {
+        maxPerHour: new NumberProtectionSetting(DEFAULT_MAX_PER_HOUR)
+    };
+
+    constructor() {
+        super();
+    }
+
+    public get name(): string {
+        return "JoinWaveShortCircuit";
+    }
+
+    public get description(): string {
+        return "If X amount of users join in Y time, set the room to invite-only."
+    }
+
+    public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any) {
+        if (event['type'] !== 'm.room.member') {
+            // Not a join/leave event.
+            return;
+        }
+
+        if (!(roomId in mjolnir.protectedRooms)) {
+            // Not a room we are watching.
+            return;
+        }
+
+        const userId = event['state_key'];
+        if (!userId) {
+            // Ill-formed event.
+            return;
+        }
+
+        const userState = event['content']['membership'];
+        const prevMembership = event['unsigned']?.['prev_content']?.['membership'] || "leave";
+
+        // We look at the previous membership to filter out profile changes
+        if (userState === 'join' && prevMembership !== "join") {
+            // A new join, fallthrough
+        } else {
+            return;
+        }
+
+        // If either the roomId bucket didn't exist, or the bucket has expired, create a new one
+        if (!this.joinBuckets[roomId] || JoinWaveShortCircuit.hasExpired(this.joinBuckets[roomId].lastBucketStart)) {
+            this.joinBuckets[roomId] = {
+                lastBucketStart: new Date(),
+                numberOfJoins: 0
+            }
+        }
+
+        if (++this.joinBuckets[roomId].numberOfJoins >= this.settings.maxPerHour.value) {
+            await mjolnir.logMessage(LogLevel.WARN, "JoinWaveShortCircuit", `Setting ${roomId} to invite-only as more than ${this.settings.maxPerHour.value} users have joined over the last hour (since ${this.joinBuckets[roomId].lastBucketStart})`, roomId);
+
+            if (!config.noop) {
+                await mjolnir.client.sendStateEvent(roomId, "m.room.join_rules", "", {"join_rule": "invite"})
+            } else {
+                await mjolnir.logMessage(LogLevel.WARN, "BasicFlooding", `Tried to set ${roomId} to invite-only, but Mjolnir is running in no-op mode`, roomId);
+            }
+        }
+    }
+
+    private static hasExpired(at: Date): boolean {
+        return ((new Date()).getTime() - at.getTime()) > ONE_HOUR
+    }
+
+    public async statusCommand(mjolnir: Mjolnir, subcommand: string[]): Promise<{ html: string, text: string }> {
+        const withExpired = subcommand.includes("withExpired");
+        const withStart = subcommand.includes("withStart");
+
+        let html = `<b>Short Circuit join buckets (max ${this.settings.maxPerHour.value} per hour):</b><br/><ul>`;
+        let text = `Short Circuit join buckets (max ${this.settings.maxPerHour.value} per hour):\n`;
+
+        for (const roomId of Object.keys(this.joinBuckets)) {
+            const bucket = this.joinBuckets[roomId];
+            const isExpired = JoinWaveShortCircuit.hasExpired(bucket.lastBucketStart);
+
+            if (isExpired && !withExpired) {
+                continue;
+            }
+
+            const startText = withStart ? ` (since ${bucket.lastBucketStart})` : "";
+            const expiredText = isExpired ? ` (bucket expired since ${new Date(bucket.lastBucketStart.getTime() + ONE_HOUR)})` : "";
+
+            html += `<li><a href="https://matrix.to/#/${roomId}">${roomId}</a>: ${bucket.numberOfJoins} joins${startText}${expiredText}.</li>`;
+            text += `* ${roomId}: ${bucket.numberOfJoins} joins${startText}${expiredText}.\n`;
+        }
+
+        html += "</ul>";
+
+        return {
+            html,
+            text,
+        }
+    }
+}

--- a/src/protections/JoinWaveShortCircuit.ts
+++ b/src/protections/JoinWaveShortCircuit.ts
@@ -90,7 +90,7 @@ export class JoinWaveShortCircuit extends Protection {
             if (!config.noop) {
                 await mjolnir.client.sendStateEvent(roomId, "m.room.join_rules", "", {"join_rule": "invite"})
             } else {
-                await mjolnir.logMessage(LogLevel.WARN, "BasicFlooding", `Tried to set ${roomId} to invite-only, but Mjolnir is running in no-op mode`, roomId);
+                await mjolnir.logMessage(LogLevel.WARN, "JoinWaveShortCircuit", `Tried to set ${roomId} to invite-only, but Mjolnir is running in no-op mode`, roomId);
             }
         }
     }

--- a/src/protections/protections.ts
+++ b/src/protections/protections.ts
@@ -22,6 +22,7 @@ import { WordList } from "./WordList";
 import { MessageIsVoice } from "./MessageIsVoice";
 import { MessageIsMedia } from "./MessageIsMedia";
 import { TrustedReporters } from "./TrustedReporters";
+import { JoinWaveShortCircuit } from "./JoinWaveShortCircuit";
 
 export const PROTECTIONS: Protection[] = [
     new FirstMessageIsImage(),
@@ -31,4 +32,5 @@ export const PROTECTIONS: Protection[] = [
     new MessageIsMedia(),
     new TrustedReporters(),
     new DetectFederationLag(),
+    new JoinWaveShortCircuit(),
 ];


### PR DESCRIPTION
This partially addresses https://github.com/matrix-org/mjolnir/issues/267

This adds `JoinWaveShortCircuit`, a protection which will set the room to invite-only as soon as X amount of users (default 50) join the room in the last X minutes (default 60).

The protection works with a Bucket, starting the bucket at first join, and only counting users if its been X minutes since the last bucket start.

(The reasoning for this particular approach is likely sensitive (in relation to other protections), so please reach out if you'd like to hear it.)

It has two settings; 
- `maxPer`, which determines how many users will have to join in the last X minutes before it will trigger the protection.
- `timescaleMinutes`, the timescale in X minutes, this determines on what time scale the bot will look at joins.

This adds a status command to the protection, with optional subcommands `withExpired` and `withStart`, to debug buckets and/or give more information.

#### Rationale

This is auto-moderation for a particular problem; Join-spam waves often come when a moderation can be inactive, busy, or otherwise unable to immediately respond. It often fills a room with hundreds of users within a few minutes. This protection is meant to "short-circuit" the wave, and keep it relatively contained for moderators to assess and clean up afterwards.
