### PR TITLE
Glob kick command

### DIFF
--- a/src/commands/CommandHandler.ts
+++ b/src/commands/CommandHandler.ts
@@ -131,7 +131,7 @@ export async function handleCommand(roomId: string, event: { content: { body: st
                 "!mjolnir unban <list shortcode> <user|room|server> <glob> [apply]   - Removes an entity from the ban list. If apply is 'true', the users matching the glob will actually be unbanned\n" +
                 "!mjolnir redact <user ID> [room alias/ID] [limit]                   - Redacts messages by the sender in the target room (or all rooms), up to a maximum number of events in the backlog (default 1000)\n" +
                 "!mjolnir redact <event permalink>                                   - Redacts a message by permalink\n" +
-                "!mjolnir kick <user ID> [room alias/ID] [reason]                    - Kicks a user in a particular room or all protected rooms\n" +
+                "!mjolnir kick <glob> [room alias/ID] [reason]                    - Kicks a user or all of those matching a glob in a particular room or all protected rooms\n" +
                 "!mjolnir rules                                                      - Lists the rules currently in use by Mjolnir\n" +
                 "!mjolnir sync                                                       - Force updates of all lists and re-apply rules\n" +
                 "!mjolnir verify                                                     - Ensures Mjolnir can moderate all your rooms\n" +

--- a/src/commands/KickCommand.ts
+++ b/src/commands/KickCommand.ts
@@ -20,7 +20,7 @@ import config from "../config";
 
 // !mjolnir kick <user|filter> [room] [reason]
 export async function execKickCommand(roomId: string, event: any, mjolnir: Mjolnir, parts: string[]) {
-    force = false;
+    let force = false;
 
     const glob = parts[2];
     let rooms = [...Object.keys(mjolnir.protectedRooms)];
@@ -30,12 +30,12 @@ export async function execKickCommand(roomId: string, event: any, mjolnir: Mjoln
         parts.pop();
     }
 
-    if (config.commands.confirmWildcardBan && /[*?]/.test(parts)) {
+    if (config.commands.confirmWildcardBan && /[*?]/.test(glob) && !force) {
         let replyMessage = "Wildcard bans require an addition `--force` argument to confirm";
         const reply = RichReply.createFor(roomId, event, replyMessage, replyMessage);
         reply["msgtype"] = "m.notice";
         await mjolnir.client.sendMessage(roomId, reply);
-        return null;
+        return;
     }
 
     const kickRule = new MatrixGlob(glob);

--- a/src/commands/KickCommand.ts
+++ b/src/commands/KickCommand.ts
@@ -37,11 +37,11 @@ export async function execKickCommand(roomId: string, event: any, mjolnir: Mjoln
     if (!reason) reason = '<none supplied>';
 
     for (const protectedRoomId of rooms) {
-        const members = await mjolnir.client.getRoomMembers(protectedRoomId, undefined, ['ban'], undefined);
+        const members = await mjolnir.client.getRoomMembers(protectedRoomId);
 
         for (const member of members) {
             const victim = member.membershipFor;
-            
+
             if (kickRule.test(victim)) {
                 await mjolnir.logMessage(LogLevel.DEBUG, "KickCommand", `Removing ${victim} in ${protectedRoomId}`, protectedRoomId);
 

--- a/src/commands/KickCommand.ts
+++ b/src/commands/KickCommand.ts
@@ -63,7 +63,7 @@ export async function execKickCommand(roomId: string, event: any, mjolnir: Mjoln
                 if (!config.noop) {
                     try {
                         await mjolnir.client.kickUser(victim, protectedRoomId, reason);
-                    } catch(e) {
+                    } catch (e) {
                         await mjolnir.logMessage(LogLevel.WARN, "KickCommand", `An error happened while trying to kick ${victim}: ${e}`);
                     }
                 } else {

--- a/src/commands/KickCommand.ts
+++ b/src/commands/KickCommand.ts
@@ -52,12 +52,12 @@ export async function execKickCommand(roomId: string, event: any, mjolnir: Mjoln
     if (!reason) reason = '<none supplied>';
 
     for (const protectedRoomId of rooms) {
-        const members = await mjolnir.client.getRoomMembers(protectedRoomId);
+        const members = await mjolnir.client.getRoomMembers(protectedRoomId, undefined, ["join"], ["ban", "leave"]);
 
         for (const member of members) {
             const victim = member.membershipFor;
 
-            if (kickRule.test(victim) && member.membership !== 'ban') {
+            if (kickRule.test(victim)) {
                 await mjolnir.logMessage(LogLevel.DEBUG, "KickCommand", `Removing ${victim} in ${protectedRoomId}`, protectedRoomId);
 
                 if (!config.noop) {

--- a/src/commands/KickCommand.ts
+++ b/src/commands/KickCommand.ts
@@ -15,13 +15,28 @@ limitations under the License.
 */
 
 import { Mjolnir } from "../Mjolnir";
-import { LogLevel, MatrixGlob } from "matrix-bot-sdk";
+import { LogLevel, MatrixGlob, RichReply } from "matrix-bot-sdk";
 import config from "../config";
 
 // !mjolnir kick <user|filter> [room] [reason]
 export async function execKickCommand(roomId: string, event: any, mjolnir: Mjolnir, parts: string[]) {
+    force = false;
+
     const glob = parts[2];
     let rooms = [...Object.keys(mjolnir.protectedRooms)];
+
+    if (parts[parts.length - 1] === "--force") {
+        force = true;
+        parts.pop();
+    }
+
+    if (config.commands.confirmWildcardBan && /[*?]/.test(parts)) {
+        let replyMessage = "Wildcard bans require an addition `--force` argument to confirm";
+        const reply = RichReply.createFor(roomId, event, replyMessage, replyMessage);
+        reply["msgtype"] = "m.notice";
+        await mjolnir.client.sendMessage(roomId, reply);
+        return null;
+    }
 
     const kickRule = new MatrixGlob(glob);
 

--- a/src/commands/KickCommand.ts
+++ b/src/commands/KickCommand.ts
@@ -61,7 +61,11 @@ export async function execKickCommand(roomId: string, event: any, mjolnir: Mjoln
                 await mjolnir.logMessage(LogLevel.DEBUG, "KickCommand", `Removing ${victim} in ${protectedRoomId}`, protectedRoomId);
 
                 if (!config.noop) {
-                    await mjolnir.client.kickUser(victim, protectedRoomId, reason);
+                    try {
+                        await mjolnir.client.kickUser(victim, protectedRoomId, reason);
+                    } catch(e) {
+                        await mjolnir.logMessage(LogLevel.WARN, "KickCommand", `An error happened while trying to kick ${victim}: ${e}`);
+                    }
                 } else {
                     await mjolnir.logMessage(LogLevel.WARN, "KickCommand", `Tried to kick ${victim} in ${protectedRoomId} but the bot is running in no-op mode.`, protectedRoomId);
                 }

--- a/src/commands/KickCommand.ts
+++ b/src/commands/KickCommand.ts
@@ -46,9 +46,9 @@ export async function execKickCommand(roomId: string, event: any, mjolnir: Mjoln
                 await mjolnir.logMessage(LogLevel.DEBUG, "KickCommand", `Removing ${victim} in ${protectedRoomId}`, protectedRoomId);
 
                 if (!config.noop) {
-                    await mjolnir.client.kickUser(userId, targetRoomId, reason);
+                    await mjolnir.client.kickUser(victim, protectedRoomId, reason);
                 } else {
-                    await mjolnir.logMessage(LogLevel.WARN, "KickCommand", `Tried to kick ${userId} in ${targetRoomId} but the bot is running in no-op mode.`, targetRoomId);
+                    await mjolnir.logMessage(LogLevel.WARN, "KickCommand", `Tried to kick ${victim} in ${protectedRoomId} but the bot is running in no-op mode.`, protectedRoomId);
                 }
             }
         }

--- a/src/commands/KickCommand.ts
+++ b/src/commands/KickCommand.ts
@@ -57,7 +57,7 @@ export async function execKickCommand(roomId: string, event: any, mjolnir: Mjoln
         for (const member of members) {
             const victim = member.membershipFor;
 
-            if (kickRule.test(victim)) {
+            if (kickRule.test(victim) && member.membership !== 'ban') {
                 await mjolnir.logMessage(LogLevel.DEBUG, "KickCommand", `Removing ${victim} in ${protectedRoomId}`, protectedRoomId);
 
                 if (!config.noop) {


### PR DESCRIPTION
This pull requests adds for glob support in the `!mjolnir kick` command.

## Example
```
!mjolnir kick @*:domain.tld <reason> --force
```
This command will kick every user having a mxid matching `domain.tld`.  
You can also still kick a particular user:
```
!mjolnir kick @user:domain.tld <reason>
```

## Tests:
Tested on the Furry Tech room (`vRGLvqJYlFvzpThbxI:matrix.org`) after a spam wave.  
It kicked over 13k bots in a matter of hours without putting too much strain on the homeserver.  
For instance, this command was matching `@spam*`:
![image](https://user-images.githubusercontent.com/76598503/167320002-f0575f50-4b54-41d1-8220-f67d72ccaf16.png)

  
  
Signed-off-by: Jae Lo Presti <me@jae.fi>