### PR TITLE
Add list shortcodes to status command output

### DIFF
--- a/src/commands/StatusCommand.ts
+++ b/src/commands/StatusCommand.ts
@@ -75,8 +75,8 @@ async function showMjolnirStatus(roomId: string, event: any, mjolnir: Mjolnir) {
     text += "Subscribed ban lists:\n";
     for (const list of mjolnir.lists) {
         const ruleInfo = `rules: ${list.serverRules.length} servers, ${list.userRules.length} users, ${list.roomRules.length} rooms`;
-        html += `<li><a href="${list.roomRef}">${list.roomId}</a> (${ruleInfo})</li>`;
-        text += `* ${list.roomRef} (${ruleInfo})\n`;
+        html += `<li>${htmlEscape(list.listShortcode)} @ <a href="${list.roomRef}">${list.roomId}</a> (${ruleInfo})</li>`;
+        text += `* ${list.listShortcode} @ ${list.roomRef} (${ruleInfo})\n`;
     }
     if (mjolnir.lists.length === 0) {
         html += "<li><i>None</i></li>";


### PR DESCRIPTION
This is a partial fix for #75. I'd add the readonly status too, but I don't think Mjolnir tracks that.