### PR TITLE
Report polling test temporality

### DIFF
--- a/test/integration/reportPollingTest.ts
+++ b/test/integration/reportPollingTest.ts
@@ -1,27 +1,21 @@
-import { strict as assert } from "assert";
-
-import config from "../../src/config";
 import { Mjolnir } from "../../src/Mjolnir";
 import { IProtection } from "../../src/protections/IProtection";
-import { PROTECTIONS } from "../../src/protections/protections";
-import { ProtectionSettingValidationError } from "../../src/protections/ProtectionSettings";
-import { NumberProtectionSetting, StringProtectionSetting, StringListProtectionSetting } from "../../src/protections/ProtectionSettings";
-import { newTestUser, noticeListener } from "./clientHelper";
-import { matrixClient, mjolnir } from "./mjolnirSetupUtils";
+import { newTestUser } from "./clientHelper";
 
 describe("Test: Report polling", function() {
     let client;
     this.beforeEach(async function () {
         client = await newTestUser({ name: { contains: "protection-settings" }});
-        await client.start();
-    })
-    this.afterEach(async function () {
-        await client.stop();
     })
     it("Mjolnir correctly retrieves a report from synapse", async function() {
         this.timeout(40000);
 
-        const reportPromise = new Promise(async (resolve, reject) => {
+        let protectedRoomId = await this.mjolnir.client.createRoom({ invite: [await client.getUserId()] });
+        await client.joinRoom(protectedRoomId);
+        await this.mjolnir.addProtectedRoom(protectedRoomId);
+
+        const eventId = await client.sendMessage(protectedRoomId, {msgtype: "m.text", body: "uwNd3q"});
+        await new Promise(async resolve => {
             await this.mjolnir.registerProtection(new class implements IProtection {
                 name = "jYvufI";
                 description = "A test protection";
@@ -33,22 +27,21 @@ describe("Test: Report polling", function() {
                     }
                 };
             });
+            await this.mjolnir.enableProtection("jYvufI");
+            await client.doRequest(
+                "POST",
+                `/_matrix/client/r0/rooms/${encodeURIComponent(protectedRoomId)}/report/${encodeURIComponent(eventId)}`, "", {
+                    reason: "x5h1Je"
+                }
+            );
         });
-        await this.mjolnir.enableProtection("jYvufI");
-
-        let protectedRoomId = await this.mjolnir.client.createRoom({ invite: [await client.getUserId()] });
-        await client.joinRoom(protectedRoomId);
-        await this.mjolnir.addProtectedRoom(protectedRoomId);
-
-        const eventId = await client.sendMessage(protectedRoomId, {msgtype: "m.text", body: "uwNd3q"});
-        await client.doRequest(
-            "POST",
-            `/_matrix/client/r0/rooms/${encodeURIComponent(protectedRoomId)}/report/${encodeURIComponent(eventId)}`, "", {
-                reason: "x5h1Je"
-            }
-        );
-
-        await reportPromise;
+        // So I kid you not, it seems like we can quit before the webserver for reports sends a respond to the client (via L#26)
+        // because the promise above gets resolved before we finish awaiting the report sending request on L#31,
+        // then mocha's cleanup code runs (and shuts down the webserver) before the webserver can respond.
+        // Wait a minute 😲😲🤯 it's not even supposed to be using the webserver if this is testing report polling.
+        // Ok, well apparently that needs a big refactor to change, but if you change the config before running this test,
+        // then you can ensure that report polling works. https://github.com/matrix-org/mjolnir/issues/326.
+        await new Promise(resolve => setTimeout(resolve, 1000));
     });
 });
 


### PR DESCRIPTION
So the test before sometimes sent the report *before*
the protection (that is used to check whether we have received
the report) was registered.
This of course meant that we didn't ever receive the report from
the perspectivee of the test.
This PR should now mean we always send the report after
registering the protection.