### PR TITLE
Use stable prefixes for policy recommendations

### DIFF
--- a/src/models/ListRule.ts
+++ b/src/models/ListRule.ts
@@ -19,7 +19,7 @@ import { MatrixGlob } from "matrix-bot-sdk";
 export const RECOMMENDATION_BAN = "m.ban";
 export const RECOMMENDATION_BAN_TYPES = [RECOMMENDATION_BAN, "org.matrix.mjolnir.ban"];
 
-export function recommendationToStable(recommendation: string, unstable = true): string|null {
+export function recommendationToStable(recommendation: string, unstable = false): string|null {
     if (RECOMMENDATION_BAN_TYPES.includes(recommendation)) return unstable ? RECOMMENDATION_BAN_TYPES[RECOMMENDATION_BAN_TYPES.length - 1] : RECOMMENDATION_BAN;
     return null;
 }


### PR DESCRIPTION
They have been in the spec for ~3 years now and most mjolnirs should be
able to handle them. Let's use the stable endpoint now, so that other
moderation tools don't need to implement the legacy identifier to handle
new bans at some point.

Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>