### PR TITLE
Access Control

### DIFF
--- a/src/ProtectedRooms.ts
+++ b/src/ProtectedRooms.ts
@@ -300,7 +300,7 @@ export class ProtectedRooms {
         const serverName: string = new UserID(await this.client.getUserId()).domain;
 
         // Construct a server ACL first
-        const acl = this.accessControlUnit.createServerAcl(serverName);
+        const acl = this.accessControlUnit.compileServerAcl(serverName);
         const finalAcl = acl.safeAclContent();
 
         if (this.config.verboseLogging) {

--- a/src/ProtectedRooms.ts
+++ b/src/ProtectedRooms.ts
@@ -374,7 +374,7 @@ export class ProtectedRooms {
                     }
 
                     // We don't want to ban people based on server ACL as this would flood the room with bans.
-                    const memberAccess = this.accessControlUnit.testUserWithoutServer(member.userId);
+                    const memberAccess = this.accessControlUnit.getAccessForUser(member.userId, "IGNORE_SERVER");
                     if (memberAccess.outcome === Access.Banned) {
                         const reason = memberAccess.rule ? memberAccess.rule.reason : '<no reason supplied>';
                         // We specifically use sendNotice to avoid having to escape HTML

--- a/src/models/AccessControlUnit.ts
+++ b/src/models/AccessControlUnit.ts
@@ -284,7 +284,7 @@ export default class AccessControlUnit {
      * @param serverName The name of the server that you are operating from, used to ensure you cannot brick yourself.
      * @returns A new `ServerAcl` instance with deny and allow entries created from the rules in this unit.
      */
-    public createServerAcl(serverName: string) {
+    public compileServerAcl(serverName: string): ServerAcl {
         const acl = new ServerAcl(serverName).denyIpAddresses();
         const allowedServers = this.serverAllows.allRules;
         // Allowed servers (allow).

--- a/src/models/AccessControlUnit.ts
+++ b/src/models/AccessControlUnit.ts
@@ -59,7 +59,7 @@ class ListRuleCache {
      * @param entity e.g. an mxid for a user, the server name for a server.
      * @returns A single `ListRule` matching the entity.
      */
-    public test(entity: string): ListRule|null {
+    public getAnyRuleForEntity(entity: string): ListRule|null {
         const literalRule = this.literalRules.get(entity);
         if (literalRule !== undefined) {
             return literalRule[0];
@@ -266,12 +266,12 @@ export default class AccessControlUnit {
     private getAccessForEntity(entity: string, allowCache: ListRuleCache, bannedCache: ListRuleCache): EntityAccess {
         // Check if the entity is explicitly allowed.
         // We have to infer that a rule exists for '*' if the allowCache is empty, otherwise you brick the ACL.
-        const allowRule = allowCache.test(entity);
+        const allowRule = allowCache.getAnyRuleForEntity(entity);
         if (allowRule === null && !allowCache.isEmpty()) {
             return { outcome: Access.NotAllowed }
         }
         // Now check if the entity is banned.
-        const banRule = bannedCache.test(entity);
+        const banRule = bannedCache.getAnyRuleForEntity(entity);
         if (banRule !== null) {
             return { outcome: Access.Banned, rule: banRule };
         }

--- a/src/models/AccessControlUnit.ts
+++ b/src/models/AccessControlUnit.ts
@@ -209,7 +209,7 @@ export interface EntityAccess {
 }
 
 /**
- * This allows us to work the access an entity has to some thing based on a set of watched/unwatched lists.
+ * This allows us to work out the access an entity has to some thing based on a set of watched/unwatched lists.
  */
 export default class AccessControlUnit {
     private readonly userBans = new ListRuleCache(RULE_USER, Recommendation.Ban);

--- a/src/models/AccessControlUnit.ts
+++ b/src/models/AccessControlUnit.ts
@@ -1,0 +1,318 @@
+/*
+Copyright 2019-2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import PolicyList, { ChangeType, ListRuleChange } from "./PolicyList";
+import { EntityType, ListRule, Recommendation, RULE_SERVER, RULE_USER } from "./ListRule";
+import { LogService, UserID } from "matrix-bot-sdk";
+import { ServerAcl } from "./ServerAcl";
+
+/**
+ * The ListRuleCache is a cache for all the rules in a list for a specific entity type and recommendation.
+ * The cache can then be used to quickly test against all the rules for that specific entity/recommendation.
+ * E.g. The cache can be used for all the m.ban rules for users in a set of lists to conveniently test members of a room.
+ * While some effort has been made to optimize the testing of entities, the main purpose of this class is to stop
+ * ad-hoc destructuring of policy lists to test rules against entities.
+ *
+ * Note: This cache should not be used to unban or introspect about the state of `PolicyLists`, for this
+ * see `PolicyList.unban` and `PolicyList.rulesMatchingEntity`, as these will make sure to account
+ * for unnormalized entity types.
+ */
+class ListRuleCache {
+    /**
+     * Glob rules always have to be scanned against every entity.
+     */
+    private readonly globRules: Map<string/** The entity that the rules specify */, ListRule[]> = new Map();
+    /**
+     * This table allows us to skip matching an entity against every literal.
+     */
+    private readonly literalRules: Map<string/* the string literal */, ListRule[]/* the rules matching this literal */> = new Map();
+    private readonly listUpdateListener: ((list: PolicyList, changes: ListRuleChange[]) => void);
+
+    constructor(
+        /**
+         * The entity type that this cache is for e.g. RULE_USER.
+         */
+        public readonly entityType: EntityType,
+        /**
+         * The recommendation that this cache is for e.g. m.ban (RECOMMENDATION_BAN).
+         */
+        public readonly recommendation: Recommendation,
+    ) {
+        this.listUpdateListener = (list: PolicyList, changes: ListRuleChange[]) => this.updateCache(changes);
+    }
+
+    /**
+     * Test the entitiy for the first matching rule out of all the watched lists.
+     * @param entity e.g. an mxid for a user, the server name for a server.
+     * @returns A single `ListRule` matching the entity.
+     */
+    public test(entity: string): ListRule|null {
+        const literalRule = this.literalRules.get(entity);
+        if (literalRule !== undefined) {
+            return literalRule[0];
+        }
+        for (const rule of this.globRules.values()) {
+            if (rule[0].isMatch(entity)) {
+                return rule[0];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Watch a list and add all its rules (and future rules) to the cache.
+     * Will automatically update with the list.
+     * @param list A PolicyList.
+     */
+    public watchList(list: PolicyList): void {
+        list.on('PolicyList.update', this.listUpdateListener);
+        const rules = list.rulesOfKind(this.entityType, this.recommendation);
+        rules.forEach(this.internRule, this);
+    }
+
+    /**
+     * Unwatch a list and remove all of its rules from the cache.
+     * Will stop updating the cache from this list.
+     * @param list A PolicyList.
+     */
+    public unwatchList(list: PolicyList): void {
+        list.removeListener('PolicyList.update', this.listUpdateListener);
+        const rules = list.rulesOfKind(this.entityType, this.recommendation);
+        rules.forEach(this.uninternRule, this);
+    }
+
+    /**
+     * @returns True when there are no rules in the cache.
+     */
+    public isEmpty(): boolean {
+        return this.globRules.size + this.literalRules.size === 0;
+    }
+
+    /**
+     * Returns all the rules in the cache, without duplicates from different lists.
+     */
+    public get allRules(): ListRule[] {
+        return [...this.literalRules.values(), ...this.globRules.values()].map(rules => rules[0]);
+    }
+
+    /**
+     * Remove a rule from the cache as it is now invalid. e.g. it was removed from a policy list.
+     * @param rule The rule to remove.
+     */
+    private uninternRule(rule: ListRule) {
+        /**
+         * Remove a rule from the map, there may be rules from different lists in the cache.
+         * We don't want to invalidate those.
+         * @param map A map of entities to rules.
+         */
+        const removeRuleFromMap = (map: Map<string, ListRule[]>) => {
+            const entry = map.get(rule.entity);
+            if (entry !== undefined) {
+                const newEntry = entry.filter(internedRule => internedRule.sourceEvent.event_id !== rule.sourceEvent.event_id);
+                if (newEntry.length === 0) {
+                    map.delete(rule.entity);
+                } else {
+                    map.set(rule.entity, newEntry);
+                }
+            }
+        };
+        if (rule.isGlob()) {
+            removeRuleFromMap(this.globRules);
+        } else {
+            removeRuleFromMap(this.literalRules);
+        }
+    }
+
+    /**
+     * Add a rule to the cache e.g. it was added to a policy list.
+     * @param rule The rule to add.
+     */
+    private internRule(rule: ListRule) {
+        /**
+         * Add a rule to the map, there might be duplicates of this rule in other lists.
+         * @param map A map of entities to rules.
+         */
+        const addRuleToMap = (map: Map<string, ListRule[]>) => {
+            const entry = map.get(rule.entity);
+            if (entry !== undefined) {
+                entry.push(rule);
+            } else {
+                map.set(rule.entity, [rule]);
+            }
+        }
+        if (rule.isGlob()) {
+            addRuleToMap(this.globRules);
+        } else {
+            addRuleToMap(this.literalRules);
+        }
+    }
+
+    /**
+     * Update the cache for a single `ListRuleChange`.
+     * @param change The change made to a rule that was present in the policy list.
+     */
+    private updataCacheForChange(change: ListRuleChange): void {
+        if (change.rule.kind !== this.entityType || change.rule.recommendation !== this.recommendation) {
+            return;
+        }
+        switch (change.changeType) {
+            case ChangeType.Added:
+            case ChangeType.Modified:
+                this.internRule(change.rule);
+                break;
+            case ChangeType.Removed:
+                this.uninternRule(change.rule);
+                break;
+            default:
+                throw new TypeError(`Uknown ListRule change type: ${change.changeType}`);
+        }
+    }
+
+    /**
+     * Update the cache for a change in a policy list.
+     * @param changes The changes that were made to list rules since the last update to this policy list.
+     */
+    private updateCache(changes: ListRuleChange[]) {
+        changes.forEach(this.updataCacheForChange, this);
+    }
+}
+
+export enum Access {
+    /// The entity was explicitly banned by a policy list.
+    Banned,
+    /// The entity did not match any allow rule.
+    NotAllowed,
+    /// The user was allowed implicitly (it matched an allow rule and did not match any banning rules).
+    Allowed,
+}
+
+/**
+ * A description of the access an entity has.
+ * If the access is `Banned`, then a single rule that bans the entity will be included.
+ */
+export interface EntityAccess {
+    readonly outcome: Access,
+    readonly rule?: ListRule,
+}
+
+/**
+ * This allows us to work the access an entity has to some thing based on a set of watched/unwatched lists.
+ */
+export default class AccessControlUnit {
+    private readonly userBans = new ListRuleCache(RULE_USER, Recommendation.Ban);
+    private readonly serverBans = new ListRuleCache(RULE_SERVER, Recommendation.Ban);
+    private readonly userAllows = new ListRuleCache(RULE_USER, Recommendation.Allow);
+    private readonly serverAllows = new ListRuleCache(RULE_SERVER, Recommendation.Allow);
+    private readonly caches = [this.userBans, this.serverBans, this.userAllows, this.serverAllows]
+
+    constructor(policyLists: PolicyList[]) {
+        policyLists.forEach(this.watchList, this);
+    }
+
+    public watchList(list: PolicyList) {
+        for (const cache of this.caches) {
+            cache.watchList(list);
+        }
+    }
+
+    public unwatchList(list: PolicyList) {
+        for (const cache of this.caches) {
+            cache.watchList(list);
+        }
+    }
+
+    /**
+     * Test whether the server is allowed by the ACL unit.
+     * @param domain The server name to test.
+     * @returns A description of the access that the server has.
+     */
+    public testServer(domain: string): EntityAccess {
+        return this.testEntity(domain, this.serverAllows, this.serverBans);
+    }
+
+    /**
+     * Test whether the user is allowed by the ACL unit.
+     * Does not test the domain of the user id.
+     * @param mxid The user id to test.
+     * @returns A description of the access that the user has.
+     */
+    public testUserWithoutServer(mxid: string): EntityAccess {
+        return this.testEntity(mxid, this.userAllows, this.userBans);
+    }
+
+    /**
+     * Test whether the user is allowed by the ACL unit. Does take the user's server into consideration.
+     * @param mxid The user id to test.
+     * @returns A description of the access that the user or their server has.
+     */
+    public testUser(mxid: UserID): EntityAccess {
+        const userAccess = this.testUserWithoutServer(mxid.toString());
+        if (userAccess.outcome === Access.Allowed) {
+            return this.testServer(mxid.domain);
+        } else {
+            return userAccess;
+        }
+    }
+
+    private testEntity(entity: string, allowCache: ListRuleCache, bannedCache: ListRuleCache): EntityAccess {
+        // Check if the entity is explicitly allowed.
+        // We have to infer that a rule exists for '*' if the allowCache is empty, otherwise you brick the ACL.
+        const allowRule = allowCache.test(entity);
+        if (allowRule === null && !allowCache.isEmpty()) {
+            return { outcome: Access.NotAllowed }
+        }
+        // Now check if the entity is banned.
+        const banRule = bannedCache.test(entity);
+        if (banRule !== null) {
+            return { outcome: Access.Banned, rule: banRule };
+        }
+        // If they got to this point, they're allowed!!
+        return { outcome: Access.Allowed };
+    }
+
+    /**
+     * Create a ServerAcl instance from the rules contained in this unit.
+     * @param serverName The name of the server that you are operating from, used to ensure you cannot brick yourself.
+     * @returns A new `ServerAcl` instance with deny and allow entries created from the rules in this unit.
+     */
+    public createServerAcl(serverName: string) {
+        const acl = new ServerAcl(serverName).denyIpAddresses();
+        const allowedServers = this.serverAllows.allRules;
+        // Allowed servers (allow).
+        if (allowedServers.length === 0) {
+            acl.allowServer('*');
+        } else {
+            for (const rule of allowedServers) {
+                acl.allowServer(rule.entity);
+            }
+            if (this.testServer(serverName).outcome === Access.NotAllowed) {
+                acl.allowServer(serverName);
+                LogService.warn('AccessControlUnit', `The server ${serverName} we are operating from was not on the allowed when constructing the server ACL, so it will be injected it into the server acl. Please check the ACL lists.`)
+            }
+        }
+        // Banned servers (deny).
+        for (const rule of this.serverBans.allRules) {
+            if (rule.isMatch(serverName)) {
+                LogService.warn('AccessControlUnit', `The server ${serverName} we are operating from was found to be banned by ${rule.entity} by a rule from the event: ${rule.sourceEvent.event_id}, `
+                    + 'while constructing a server acl. Ignoring the rule. Please check the ACL lists.'
+                );
+            } else {
+                acl.denyServer(rule.entity);
+            }
+        }
+        return acl;
+    }
+}

--- a/src/models/AccessControlUnit.ts
+++ b/src/models/AccessControlUnit.ts
@@ -164,7 +164,7 @@ class ListRuleCache {
      * Update the cache for a single `ListRuleChange`.
      * @param change The change made to a rule that was present in the policy list.
      */
-    private updataCacheForChange(change: ListRuleChange): void {
+    private updateCacheForChange(change: ListRuleChange): void {
         if (change.rule.kind !== this.entityType || change.rule.recommendation !== this.recommendation) {
             return;
         }
@@ -186,7 +186,7 @@ class ListRuleCache {
      * @param changes The changes that were made to list rules since the last update to this policy list.
      */
     private updateCache(changes: ListRuleChange[]) {
-        changes.forEach(this.updataCacheForChange, this);
+        changes.forEach(this.updateCacheForChange, this);
     }
 }
 

--- a/src/models/AccessControlUnit.ts
+++ b/src/models/AccessControlUnit.ts
@@ -195,7 +195,7 @@ export enum Access {
     Banned,
     /// The entity did not match any allow rule.
     NotAllowed,
-    /// The user was allowed implicitly (it matched an allow rule and did not match any banning rules).
+    /// The user was allowed and didn't match any ban.
     Allowed,
 }
 

--- a/src/models/AccessControlUnit.ts
+++ b/src/models/AccessControlUnit.ts
@@ -20,7 +20,7 @@ import { LogService, UserID } from "matrix-bot-sdk";
 import { ServerAcl } from "./ServerAcl";
 
 /**
- * The ListRuleCache is a cache for all the rules in a list for a specific entity type and recommendation.
+ * The ListRuleCache is a cache for all the rules in a set of lists for a specific entity type and recommendation.
  * The cache can then be used to quickly test against all the rules for that specific entity/recommendation.
  * E.g. The cache can be used for all the m.ban rules for users in a set of lists to conveniently test members of a room.
  * While some effort has been made to optimize the testing of entities, the main purpose of this class is to stop

--- a/src/models/PolicyList.ts
+++ b/src/models/PolicyList.ts
@@ -89,7 +89,8 @@ class PolicyList extends EventEmitter {
     /**
      * This is used to annotate state events we store with the rule they are associated with.
      * If we refactor this, it is important to also refactor any listeners to 'PolicyList.update'
-     * which will assume `ListRule`s that are removed will be identital (Object.is) to when they were added.
+     * which may assume `ListRule`s that are removed will be identital (Object.is) to when they were added.
+     * This behaviour should be avoided.
      */
     private static readonly EVENT_RULE_ANNOTATION_KEY = 'org.matrix.mjolnir.annotation.rule';
 

--- a/src/models/PolicyList.ts
+++ b/src/models/PolicyList.ts
@@ -87,6 +87,13 @@ class PolicyList extends EventEmitter {
     private batchedEvents = new Set<string /* event id */>();
 
     /**
+     * This is used to annotate state events we store with the rule they are associated with.
+     * If we refactor this, it is important to also refactor any listeners to 'PolicyList.update'
+     * which will assume `ListRule`s that are removed will be identital (Object.is) to when they were added.
+     */
+    private static readonly EVENT_RULE_ANNOTATION_KEY = 'org.matrix.mjolnir.annotation.rule';
+
+    /**
      * Construct a PolicyList, does not synchronize with the room.
      * @param roomId The id of the policy room, i.e. a room containing MSC2313 policies.
      * @param roomRef A sharable/clickable matrix URL that refers to the room.
@@ -134,19 +141,23 @@ class PolicyList extends EventEmitter {
     /**
      * Return all the active rules of a given kind.
      * @param kind e.g. RULE_SERVER (m.policy.rule.server). Rule types are always normalised when they are interned into the PolicyList.
+     * @param recommendation A specific recommendation to filter for e.g. `m.ban`. Please remember recommendation varients are normalized.
      * @returns The active ListRules for the ban list of that kind.
+     * FIXME: it would be nice if this was a generic to the ListRule type, (and get the recommendation type from it) but that seems hard to do, maybe impossible?.
+     * TFW you mess up type erasure so bad comeon.
      */
-    private rulesOfKind(kind: string): ListRule[] {
+    public rulesOfKind(kind: string, recommendation?: Recommendation): ListRule[] {
         const rules: ListRule[] = []
         const stateKeyMap = this.state.get(kind);
         if (stateKeyMap) {
             for (const event of stateKeyMap.values()) {
-                const rule = event?.unsigned?.rule;
-                // README! If you are refactoring this and/or introducing a mechanism to return the list of rules,
-                // please make sure that you *only* return rules with `m.ban` or create a different method
-                // (we don't want to accidentally ban entities).
-                if (rule && rule.kind === kind && rule.recommendation === Recommendation.Ban) {
-                    rules.push(rule);
+                const rule = event[PolicyList.EVENT_RULE_ANNOTATION_KEY];
+                if (rule && rule.kind === kind) {
+                    if (recommendation === undefined) {
+                        rules.push(rule);
+                    } else if (rule.recommendation === recommendation) {
+                        rules.push(rule);
+                    }
                 }
             }
         }
@@ -353,10 +364,10 @@ class PolicyList extends EventEmitter {
 
             // If we haven't got any information about what the rule used to be, then it wasn't a valid rule to begin with
             // and so will not have been used. Removing a rule like this therefore results in no change.
-            if (changeType === ChangeType.Removed && previousState?.unsigned?.rule) {
+            if (changeType === ChangeType.Removed && previousState?.[PolicyList.EVENT_RULE_ANNOTATION_KEY]) {
                 const sender = event.unsigned['redacted_because'] ? event.unsigned['redacted_because']['sender'] : event.sender;
                 changes.push({
-                    changeType, event, sender, rule: previousState.unsigned.rule,
+                    changeType, event, sender, rule: previousState[PolicyList.EVENT_RULE_ANNOTATION_KEY],
                     ...previousState ? { previousState } : {}
                 });
                 // Event has no content and cannot be parsed as a ListRule.
@@ -368,7 +379,7 @@ class PolicyList extends EventEmitter {
                 // Invalid/unknown rule, just skip it.
                 continue;
             }
-            event.unsigned.rule = rule;
+            event[PolicyList.EVENT_RULE_ANNOTATION_KEY] = rule;
             if (changeType) {
                 changes.push({ rule, changeType, event, sender: event.sender, ...previousState ? { previousState } : {} });
             }

--- a/src/models/PolicyList.ts
+++ b/src/models/PolicyList.ts
@@ -90,7 +90,7 @@ class PolicyList extends EventEmitter {
      * This is used to annotate state events we store with the rule they are associated with.
      * If we refactor this, it is important to also refactor any listeners to 'PolicyList.update'
      * which may assume `ListRule`s that are removed will be identital (Object.is) to when they were added.
-     * This behaviour should be avoided.
+     * If you are adding new listeners, you should check the source event_id of the rule.
      */
     private static readonly EVENT_RULE_ANNOTATION_KEY = 'org.matrix.mjolnir.annotation.rule';
 
@@ -144,8 +144,6 @@ class PolicyList extends EventEmitter {
      * @param kind e.g. RULE_SERVER (m.policy.rule.server). Rule types are always normalised when they are interned into the PolicyList.
      * @param recommendation A specific recommendation to filter for e.g. `m.ban`. Please remember recommendation varients are normalized.
      * @returns The active ListRules for the ban list of that kind.
-     * FIXME: it would be nice if this was a generic to the ListRule type, (and get the recommendation type from it) but that seems hard to do, maybe impossible?.
-     * TFW you mess up type erasure so bad comeon.
      */
     public rulesOfKind(kind: string, recommendation?: Recommendation): ListRule[] {
         const rules: ListRule[] = []

--- a/test/integration/banListTest.ts
+++ b/test/integration/banListTest.ts
@@ -224,7 +224,7 @@ describe('Test: We will not be able to ban ourselves via ACL.', function() {
         assert.equal(acl.safeAclContent().deny.length, 1);
         assert.equal(acl.literalAclContent().deny.length, 3);
 
-        const aclUnitAcl = aclUnit.createServerAcl(serverName);
+        const aclUnitAcl = aclUnit.compileServerAcl(serverName);
         assert.equal(aclUnitAcl.literalAclContent().deny.length, 1);
 
     })

--- a/test/integration/banListTest.ts
+++ b/test/integration/banListTest.ts
@@ -6,7 +6,8 @@ import { ServerAcl } from "../../src/models/ServerAcl";
 import { getFirstReaction } from "./commands/commandUtils";
 import { getMessagesByUserIn } from "../../src/utils";
 import { Mjolnir } from "../../src/Mjolnir";
-import { ALL_RULE_TYPES, RULE_SERVER, RULE_USER, SERVER_RULE_TYPES } from "../../src/models/ListRule";
+import { ALL_RULE_TYPES, Recommendation, RULE_SERVER, RULE_USER, SERVER_RULE_TYPES } from "../../src/models/ListRule";
+import AccessControlUnit, { Access, EntityAccess } from "../../src/models/AccessControlUnit";
 
 /**
  * Create a policy rule in a policy room.
@@ -24,6 +25,19 @@ async function createPolicyRule(client: MatrixClient, policyRoomId: string, poli
         reason,
         ...template,
     });
+}
+
+/**
+ * Remove a policy rule from a list.
+ * @param client A matrix client that is logged in
+ * @param policyRoomId The room id to add the policy to.
+ * @param policyType The type of policy to add e.g. m.policy.rule.user. (Use RULE_USER though).
+ * @param entity The entity to ban e.g. @foo:example.org
+ * @param stateKey The key for the rule.
+ * @returns The event id of the void rule that was created to override the old one.
+ */
+async function removePolicyRule(client: MatrixClient, policyRoomId: string, policyType: string, entity: string, stateKey = `rule:${entity}`) {
+    return await client.sendStateEvent(policyRoomId, policyType, stateKey, {});
 }
 
 describe("Test: Updating the PolicyList", function() {
@@ -191,28 +205,13 @@ describe("Test: Updating the PolicyList", function() {
     })
 });
 
-describe('Test: We do not respond to recommendations other than m.ban in the PolicyList', function() {
-    it('Will not respond to a rule that has a different recommendation to m.ban (or the unstable equivalent).', async function() {
-        const mjolnir: Mjolnir = this.mjolnir!
-        const banListId = await mjolnir.client.createRoom();
-        const banList = new PolicyList(banListId, banListId, mjolnir.client);
-        await createPolicyRule(mjolnir.client, banListId, RULE_SERVER, 'exmaple.org', '', { recommendation: 'something that is not m.ban' });
-        let changes: ListRuleChange[] = await banList.updateList();
-        assert.equal(changes.length, 1, 'There should only be one change');
-        assert.equal(changes[0].changeType, ChangeType.Added);
-        assert.equal(changes[0].sender, await mjolnir.client.getUserId());
-        // We really don't want things that aren't m.ban to end up being accessible in these APIs.
-        assert.equal(banList.serverRules.length, 0, `We should have an empty serverRules, got ${JSON.stringify(banList.serverRules)}`);
-        assert.equal(banList.allRules.length, 0, `We should have an empty allRules, got ${JSON.stringify(banList.allRules)}`);
-    })
-})
-
 describe('Test: We will not be able to ban ourselves via ACL.', function() {
     it('We do not ban ourselves when we put ourselves into the policy list.', async function() {
         const mjolnir: Mjolnir = this.mjolnir
         const serverName = new UserID(await mjolnir.client.getUserId()).domain;
         const banListId = await mjolnir.client.createRoom();
         const banList = new PolicyList(banListId, banListId, mjolnir.client);
+        const aclUnit = new AccessControlUnit([banList]);
         await createPolicyRule(mjolnir.client, banListId, RULE_SERVER, serverName, '');
         await createPolicyRule(mjolnir.client, banListId, RULE_SERVER, 'evil.com', '');
         await createPolicyRule(mjolnir.client, banListId, RULE_SERVER, '*', '');
@@ -224,6 +223,10 @@ describe('Test: We will not be able to ban ourselves via ACL.', function() {
         changes.forEach(change => acl.denyServer(change.rule.entity));
         assert.equal(acl.safeAclContent().deny.length, 1);
         assert.equal(acl.literalAclContent().deny.length, 3);
+
+        const aclUnitAcl = aclUnit.createServerAcl(serverName);
+        assert.equal(aclUnitAcl.literalAclContent().deny.length, 1);
+
     })
 })
 
@@ -455,5 +458,109 @@ describe('Test: should apply bans to the most recently active rooms first', func
             assert.equal(roomAclEvent.origin_server_ts > last_event_ts, true, `This room was more recently active so should have the more recent timestamp`);
             last_event_ts = roomAclEvent.origin_server_ts;
         }
+    })
+})
+
+/**
+ * Assert that the AccessUnitOutcome entity test has the right access.
+ * @param expected The Access we expect the entity to have, See Access.
+ * @param query The result of a test on AccessControlUnit e.g. `unit.testUser('@meow:localhost')`
+ * @param message A message for the console if the entity doesn't have the expected access.
+ */
+function assertAccess(expected: Access, query: EntityAccess, message?: string) {
+    assert.equal(query.outcome, expected, message);
+}
+
+describe('Test: AccessControlUnit interaction with policy lists.', function() {
+    it('The AccessControlUnit correctly reflects the policies that have been set in its watched lists.', async function() {
+        const mjolnir: Mjolnir = this.mjolnir!
+        const policyListId = await mjolnir.client.createRoom();
+        const policyList = new PolicyList(policyListId, Permalinks.forRoom(policyListId), mjolnir.client);
+        const aclUnit = new AccessControlUnit([policyList]);
+        assertAccess(Access.Allowed, aclUnit.testUser(new UserID('@anyone:anywhere.example.com')), 'Empty lists should implicitly allow.');
+
+        await createPolicyRule(mjolnir.client, policyListId, RULE_SERVER, 'matrix.org', '', { recommendation: Recommendation.Allow });
+        // we want to imagine that the banned server was never taken off the allow after being banned.
+        await createPolicyRule(mjolnir.client, policyListId, RULE_SERVER, 'bad.example.com', '', { recommendation: Recommendation.Allow }, 'something-else');
+        await createPolicyRule(mjolnir.client, policyListId, RULE_SERVER, 'bad.example.com', '', { recommendation: Recommendation.Ban });
+        await createPolicyRule(mjolnir.client, policyListId, RULE_SERVER, '*.ddns.example.com', '', { recommendation: Recommendation.Ban });
+
+        await policyList.updateList();
+
+        assertAccess(Access.Allowed, aclUnit.testServer('matrix.org'));
+        assertAccess(Access.Allowed, aclUnit.testUser(new UserID('@someone:matrix.org')));
+        assertAccess(Access.NotAllowed, aclUnit.testServer('anywhere.else.example.com'));
+        assertAccess(Access.NotAllowed, aclUnit.testUser(new UserID('@anyone:anywhere.else.example.com')));
+        assertAccess(Access.Banned, aclUnit.testServer('bad.example.com'));
+        assertAccess(Access.Banned, aclUnit.testUser(new UserID('@anyone:bad.example.com')));
+        // They're not allowed in the first place, never mind that they are also banned.
+        assertAccess(Access.NotAllowed, aclUnit.testServer('meow.ddns.example.com'));
+        assertAccess(Access.NotAllowed, aclUnit.testUser(new UserID('@anyone:meow.ddns.example.com')));
+
+        assertAccess(Access.Allowed, aclUnit.testUser(new UserID('@spam:matrix.org')));
+        await createPolicyRule(mjolnir.client, policyListId, RULE_USER, '@spam:matrix.org', '', { recommendation: Recommendation.Ban });
+        await policyList.updateList();
+        assertAccess(Access.Banned, aclUnit.testUser(new UserID('@spam:matrix.org')));
+        assertAccess(Access.Allowed, aclUnit.testUser(new UserID('@someone:matrix.org')));
+
+        // protect a room and check that only bad.example.com, *.ddns.example.com are in the deny ACL and not matrix.org
+        await mjolnir.watchList(policyList.roomRef);
+        const protectedRoom = await mjolnir.client.createRoom();
+        await mjolnir.protectedRoomsTracker.addProtectedRoom(protectedRoom);
+        await mjolnir.protectedRoomsTracker.syncLists();
+        const roomAcl = await mjolnir.client.getRoomStateEvent(protectedRoom, "m.room.server_acl", "");
+        assert.equal(roomAcl?.deny?.length ?? 0, 2, 'There should be two entries in the deny ACL.');
+        for (const serverGlob of ["*.ddns.example.com", "bad.example.com"]) {
+            assert.equal((roomAcl?.deny ?? []).includes(serverGlob), true);
+        }
+        assert.equal(roomAcl.deny.includes("matrix.org"), false);
+        assert.equal(roomAcl.allow.includes("matrix.org"), true);
+
+        // Now we remove the rules and hope that everything functions noramally.
+        await removePolicyRule(mjolnir.client, policyListId, RULE_SERVER, 'matrix.org');
+        await removePolicyRule(mjolnir.client, policyListId, RULE_SERVER, 'bad.example.com', 'something-else');
+        await removePolicyRule(mjolnir.client, policyListId, RULE_SERVER, 'bad.example.com');
+        await removePolicyRule(mjolnir.client, policyListId, RULE_SERVER, '*.ddns.example.com');
+        await removePolicyRule(mjolnir.client, policyListId, RULE_USER, "@spam:matrix.org");
+        const changes = await policyList.updateList()
+        await mjolnir.protectedRoomsTracker.syncLists();
+
+        assert.equal(changes.length, 5, "The rules should have correctly been removed");
+        assertAccess(Access.Allowed, aclUnit.testServer('matrix.org'));
+        assertAccess(Access.Allowed, aclUnit.testUser(new UserID('@someone:matrix.org')));
+        assertAccess(Access.Allowed, aclUnit.testServer('anywhere.else.example.com'));
+        assertAccess(Access.Allowed, aclUnit.testUser(new UserID('@anyone:anywhere.else.example.com')));
+        assertAccess(Access.Allowed, aclUnit.testServer('bad.example.com'));
+        assertAccess(Access.Allowed, aclUnit.testUser(new UserID('@anyone:bad.example.com')));
+        assertAccess(Access.Allowed, aclUnit.testServer('meow.ddns.example.com'));
+        assertAccess(Access.Allowed, aclUnit.testUser(new UserID('@anyone:meow.ddns.example.com')));
+        assertAccess(Access.Allowed, aclUnit.testUser(new UserID('@spam:matrix.org')));
+
+        const roomAclAfter = await mjolnir.client.getRoomStateEvent(protectedRoom, "m.room.server_acl", "");
+        assert.equal(roomAclAfter.deny?.length ?? 0, 0, 'There should be no entries in the deny ACL.');
+        assert.equal(roomAclAfter.allow?.length ?? 0, 1, 'There should be 1 entry in the allow ACL.');
+        assert.equal(roomAclAfter.allow.includes("*"), true);
+    })
+    it('removing a rule from a different list will not clobber anything.', async function() {
+        const mjolnir: Mjolnir = this.mjolnir!
+        const policyLists = await Promise.all([...Array(2).keys()].map(async _ => {
+            const policyListId = await mjolnir.client.createRoom();
+            return new PolicyList(policyListId, Permalinks.forRoom(policyListId), mjolnir.client);
+        }));
+        const banMeServer = 'banme.example.com';
+        const aclUnit = new AccessControlUnit(policyLists);
+        await Promise.all(policyLists.map(policyList => {
+            return createPolicyRule(mjolnir.client, policyList.roomId, RULE_SERVER, banMeServer, '', { recommendation: Recommendation.Ban })
+        }));
+        await Promise.all(policyLists.map(list => list.updateList()));
+        assertAccess(Access.Banned, aclUnit.testServer(banMeServer));
+
+        // remove the rule that bans `banme.example.com` from just one of the lists.
+        await removePolicyRule(mjolnir.client, policyLists[0].roomId, RULE_SERVER, banMeServer);
+        await Promise.all(policyLists.map(list => list.updateList()));
+        assertAccess(Access.Banned, aclUnit.testServer(banMeServer), "Should still be banned at this point.");
+        await removePolicyRule(mjolnir.client, policyLists[1].roomId, RULE_SERVER, banMeServer);
+        await Promise.all(policyLists.map(list => list.updateList()));
+        assertAccess(Access.Allowed, aclUnit.testServer(banMeServer), "Should not longer be any rules");
     })
 })


### PR DESCRIPTION
This PR creates a new model called an AccessControlUnit.
The ACL unit allows you to combine an policy lists and conveniently test users and servers against them.
The main motivation for this work is provide access control on who can provision and continue to use mjolnir instances in the appservice component.
We include a new recommendation type `org.matrix.mjolnir.allow` which can be used with user and server entity types to create allow lists.
We have also replaced the destructing of policy lists in `applyServerACL` and `applyMemberBans` (in `ProtectedRooms.ts`) with calls to the AccessControlUnit. 
Adding commands to add/remove allowed entities is not something i want to do at the moment. 