### PR TITLE
Early draft of caching

### DIFF
--- a/src/ProtectedRooms.ts
+++ b/src/ProtectedRooms.ts
@@ -152,7 +152,7 @@ export class ProtectedRooms {
      * @returns The list of errors encountered, for reporting to the management room.
      */
     public async processRedactionQueue(roomId?: string): Promise<RoomUpdateError[]> {
-        return await this.eventRedactionQueue.process(this.client.uncached, this.managementRoomOutput, roomId);
+        return await this.eventRedactionQueue.process(this.client, this.managementRoomOutput, roomId);
     }
 
     /**

--- a/src/commands/AddRemoveProtectedRoomsCommand.ts
+++ b/src/commands/AddRemoveProtectedRoomsCommand.ts
@@ -19,20 +19,20 @@ import { extractRequestError, LogLevel, LogService } from "matrix-bot-sdk";
 
 // !mjolnir rooms add <room alias/ID>
 export async function execAddProtectedRoom(roomId: string, event: any, mjolnir: Mjolnir, parts: string[]) {
-    const protectedRoomId = await mjolnir.client.joinRoom(parts[3]);
+    const protectedRoomId = await mjolnir.client.uncached.joinRoom(parts[3]);
     await mjolnir.addProtectedRoom(protectedRoomId);
-    await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
 }
 
 // !mjolnir rooms remove <room alias/ID>
 export async function execRemoveProtectedRoom(roomId: string, event: any, mjolnir: Mjolnir, parts: string[]) {
-    const protectedRoomId = await mjolnir.client.resolveRoom(parts[3]);
+    const protectedRoomId = await mjolnir.client.uncached.resolveRoom(parts[3]);
     await mjolnir.removeProtectedRoom(protectedRoomId);
     try {
-        await mjolnir.client.leaveRoom(protectedRoomId);
+        await mjolnir.client.uncached.leaveRoom(protectedRoomId);
     } catch (e) {
         LogService.warn("AddRemoveProtectedRoomsCommand", extractRequestError(e));
         await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "AddRemoveProtectedRoomsCommand", `Failed to leave ${protectedRoomId} - the room is no longer being protected, but the bot could not leave`, protectedRoomId);
     }
-    await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
 }

--- a/src/commands/AddRemoveRoomFromDirectoryCommand.ts
+++ b/src/commands/AddRemoveRoomFromDirectoryCommand.ts
@@ -23,14 +23,14 @@ async function addRemoveFromDirectory(inRoomId: string, event: any, mjolnir: Mjo
         const message = "I am not a Synapse administrator, or the endpoint is blocked";
         const reply = RichReply.createFor(inRoomId, event, message, message);
         reply['msgtype'] = "m.notice";
-        mjolnir.client.sendMessage(inRoomId, reply);
+        mjolnir.client.uncached.sendMessage(inRoomId, reply);
         return;
     }
 
-    const targetRoomId = await mjolnir.client.resolveRoom(roomRef);
-    await mjolnir.client.setDirectoryVisibility(targetRoomId, visibility);
+    const targetRoomId = await mjolnir.client.uncached.resolveRoom(roomRef);
+    await mjolnir.client.uncached.setDirectoryVisibility(targetRoomId, visibility);
 
-    await mjolnir.client.unstableApis.addReactionToEvent(inRoomId, event['event_id'], '✅');
+    await mjolnir.client.uncached.unstableApis.addReactionToEvent(inRoomId, event['event_id'], '✅');
 }
 
 // !mjolnir directory add <room>

--- a/src/commands/AliasCommands.ts
+++ b/src/commands/AliasCommands.ts
@@ -28,15 +28,15 @@ export async function execMoveAliasCommand(roomId: string, event: any, mjolnir: 
         const message = "I am not a Synapse administrator, or the endpoint is blocked";
         const reply = RichReply.createFor(roomId, event, message, message);
         reply['msgtype'] = "m.notice";
-        mjolnir.client.sendMessage(roomId, reply);
+        mjolnir.client.uncached.sendMessage(roomId, reply);
         return;
     }
 
-    await mjolnir.client.deleteRoomAlias(movingAlias);
-    const newRoomId = await mjolnir.client.resolveRoom(targetRoom);
-    await mjolnir.client.createRoomAlias(movingAlias, newRoomId);
+    await mjolnir.client.uncached.deleteRoomAlias(movingAlias);
+    const newRoomId = await mjolnir.client.uncached.resolveRoom(targetRoom);
+    await mjolnir.client.uncached.createRoomAlias(movingAlias, newRoomId);
 
-    await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
 }
 
 // !mjolnir alias add <alias> <target room>
@@ -49,14 +49,14 @@ export async function execAddAliasCommand(roomId: string, event: any, mjolnir: M
         const message = "I am not a Synapse administrator, or the endpoint is blocked";
         const reply = RichReply.createFor(roomId, event, message, message);
         reply['msgtype'] = "m.notice";
-        mjolnir.client.sendMessage(roomId, reply);
+        mjolnir.client.uncached.sendMessage(roomId, reply);
         return;
     }
 
-    const newRoomId = await mjolnir.client.resolveRoom(targetRoom);
-    await mjolnir.client.createRoomAlias(aliasToAdd, newRoomId);
+    const newRoomId = await mjolnir.client.uncached.resolveRoom(targetRoom);
+    await mjolnir.client.uncached.createRoomAlias(aliasToAdd, newRoomId);
 
-    await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
 }
 
 // !mjolnir alias remove <alias>
@@ -68,24 +68,24 @@ export async function execRemoveAliasCommand(roomId: string, event: any, mjolnir
         const message = "I am not a Synapse administrator, or the endpoint is blocked";
         const reply = RichReply.createFor(roomId, event, message, message);
         reply['msgtype'] = "m.notice";
-        mjolnir.client.sendMessage(roomId, reply);
+        mjolnir.client.uncached.sendMessage(roomId, reply);
         return;
     }
 
-    await mjolnir.client.deleteRoomAlias(aliasToRemove);
+    await mjolnir.client.uncached.deleteRoomAlias(aliasToRemove);
 
-    await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
 }
 
 // !mjolnir resolve <alias>
 export async function execResolveCommand(roomId: string, event: any, mjolnir: Mjolnir, parts: string[]) {
     const toResolve = parts[2];
 
-    const resolvedRoomId = await mjolnir.client.resolveRoom(toResolve);
+    const resolvedRoomId = await mjolnir.client.uncached.resolveRoom(toResolve);
 
     const message = `Room ID for ${toResolve} is ${resolvedRoomId}`;
     const html = `Room ID for ${htmlEscape(toResolve)} is ${htmlEscape(resolvedRoomId)}`;
     const reply = RichReply.createFor(roomId, event, message, html);
     reply["msgtype"] = "m.notice";
-    await mjolnir.client.sendMessage(roomId, reply);
+    await mjolnir.client.uncached.sendMessage(roomId, reply);
 }

--- a/src/commands/CommandHandler.ts
+++ b/src/commands/CommandHandler.ts
@@ -171,13 +171,13 @@ export async function handleCommand(roomId: string, event: { content: { body: st
             const text = `Mjolnir help:\n${menu}`;
             const reply = RichReply.createFor(roomId, event, text, html);
             reply["msgtype"] = "m.notice";
-            return await mjolnir.client.sendMessage(roomId, reply);
+            return await mjolnir.client.uncached.sendMessage(roomId, reply);
         }
     } catch (e) {
         LogService.error("CommandHandler", extractRequestError(e));
         const text = "There was an error processing your command - see console/log for details";
         const reply = RichReply.createFor(roomId, event, text, text);
         reply["msgtype"] = "m.notice";
-        return await mjolnir.client.sendMessage(roomId, reply);
+        return await mjolnir.client.uncached.sendMessage(roomId, reply);
     }
 }

--- a/src/commands/CreateBanListCommand.ts
+++ b/src/commands/CreateBanListCommand.ts
@@ -38,13 +38,13 @@ export async function execCreateListCommand(roomId: string, event: any, mjolnir:
         "redact": 50,
         "state_default": 50,
         "users": {
-            [await mjolnir.client.getUserId()]: 100,
+            [mjolnir.client.userId]: 100,
             [event["sender"]]: 50
         },
         "users_default": 0,
     };
 
-    const listRoomId = await mjolnir.client.createRoom({
+    const listRoomId = await mjolnir.client.uncached.createRoom({
         preset: "public_chat",
         room_alias_name: aliasLocalpart,
         invite: [event['sender']],
@@ -59,5 +59,5 @@ export async function execCreateListCommand(roomId: string, event: any, mjolnir:
     const text = `Created new list (${roomRef}). This list is now being watched.`;
     const reply = RichReply.createFor(roomId, event, text, html);
     reply["msgtype"] = "m.notice";
-    await mjolnir.client.sendMessage(roomId, reply);
+    await mjolnir.client.uncached.sendMessage(roomId, reply);
 }

--- a/src/commands/DeactivateCommand.ts
+++ b/src/commands/DeactivateCommand.ts
@@ -26,10 +26,10 @@ export async function execDeactivateCommand(roomId: string, event: any, mjolnir:
         const message = "I am not a Synapse administrator, or the endpoint is blocked";
         const reply = RichReply.createFor(roomId, event, message, message);
         reply['msgtype'] = "m.notice";
-        mjolnir.client.sendMessage(roomId, reply);
+        mjolnir.client.uncached.sendMessage(roomId, reply);
         return;
     }
 
     await mjolnir.deactivateSynapseUser(victim);
-    await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
 }

--- a/src/commands/DumpRulesCommand.ts
+++ b/src/commands/DumpRulesCommand.ts
@@ -72,7 +72,7 @@ export async function execRulesMatchingCommand(roomId: string, event: any, mjoln
     }
     const reply = RichReply.createFor(roomId, event, text, html);
     reply["msgtype"] = "m.notice";
-    return mjolnir.client.sendMessage(roomId, reply);
+    return mjolnir.client.uncached.sendMessage(roomId, reply);
 }
 
 // !mjolnir rules
@@ -124,5 +124,5 @@ export async function execDumpRulesCommand(roomId: string, event: any, mjolnir: 
 
     const reply = RichReply.createFor(roomId, event, text, html);
     reply["msgtype"] = "m.notice";
-    return mjolnir.client.sendMessage(roomId, reply);
+    return mjolnir.client.uncached.sendMessage(roomId, reply);
 }

--- a/src/commands/KickCommand.ts
+++ b/src/commands/KickCommand.ts
@@ -33,7 +33,7 @@ export async function execKickCommand(roomId: string, event: any, mjolnir: Mjoln
         let replyMessage = "Wildcard bans require an addition `--force` argument to confirm";
         const reply = RichReply.createFor(roomId, event, replyMessage, replyMessage);
         reply["msgtype"] = "m.notice";
-        await mjolnir.client.sendMessage(roomId, reply);
+        await mjolnir.client.uncached.sendMessage(roomId, reply);
         return;
     }
 
@@ -43,7 +43,7 @@ export async function execKickCommand(roomId: string, event: any, mjolnir: Mjoln
     if (parts.length > 3) {
         let reasonIndex = 3;
         if (parts[3].startsWith("#") || parts[3].startsWith("!")) {
-            rooms = [await mjolnir.client.resolveRoom(parts[3])];
+            rooms = [await mjolnir.client.uncached.resolveRoom(parts[3])];
             reasonIndex = 4;
         }
         reason = parts.slice(reasonIndex).join(' ') || '<no reason supplied>';
@@ -51,7 +51,7 @@ export async function execKickCommand(roomId: string, event: any, mjolnir: Mjoln
     if (!reason) reason = '<none supplied>';
 
     for (const protectedRoomId of rooms) {
-        const members = await mjolnir.client.getRoomMembers(protectedRoomId, undefined, ["join"], ["ban", "leave"]);
+        const members = await mjolnir.client.uncached.getRoomMembers(protectedRoomId, undefined, ["join"], ["ban", "leave"]);
 
         for (const member of members) {
             const victim = member.membershipFor;
@@ -62,7 +62,7 @@ export async function execKickCommand(roomId: string, event: any, mjolnir: Mjoln
                 if (!mjolnir.config.noop) {
                     try {
                         await mjolnir.taskQueue.push(async () => {
-                            return mjolnir.client.kickUser(victim, protectedRoomId, reason);
+                            return mjolnir.client.uncached.kickUser(victim, protectedRoomId, reason);
                         });
                     } catch (e) {
                         await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "KickCommand", `An error happened while trying to kick ${victim}: ${e}`);
@@ -74,5 +74,5 @@ export async function execKickCommand(roomId: string, event: any, mjolnir: Mjoln
         }
     }
 
-    return mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    return mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
 }

--- a/src/commands/ListProtectedRoomsCommand.ts
+++ b/src/commands/ListProtectedRoomsCommand.ts
@@ -41,5 +41,5 @@ export async function execListProtectedRooms(roomId: string, event: any, mjolnir
 
     const reply = RichReply.createFor(roomId, event, text, html);
     reply["msgtype"] = "m.notice";
-    return mjolnir.client.sendMessage(roomId, reply);
+    return mjolnir.client.uncached.sendMessage(roomId, reply);
 }

--- a/src/commands/MakeRoomAdminCommand.ts
+++ b/src/commands/MakeRoomAdminCommand.ts
@@ -24,19 +24,19 @@ export async function execMakeRoomAdminCommand(roomId: string, event: any, mjoln
         const message = "Either the command is disabled or I am not running as homeserver administrator.";
         const reply = RichReply.createFor(roomId, event, message, message);
         reply['msgtype'] = "m.notice";
-        mjolnir.client.sendMessage(roomId, reply);
+        mjolnir.client.uncached.sendMessage(roomId, reply);
         return;
     }
 
-    let err = await mjolnir.makeUserRoomAdmin(await mjolnir.client.resolveRoom(parts[3]), parts[4]);
+    let err = await mjolnir.makeUserRoomAdmin(await mjolnir.client.uncached.resolveRoom(parts[3]), parts[4]);
     if (err instanceof Error || typeof (err) === "string") {
         const errMsg = "Failed to process command:";
         const message = typeof (err) === "string" ? `${errMsg}: ${err}` : `${errMsg}: ${err.message}`;
         const reply = RichReply.createFor(roomId, event, message, message);
         reply['msgtype'] = "m.notice";
-        mjolnir.client.sendMessage(roomId, reply);
+        mjolnir.client.uncached.sendMessage(roomId, reply);
         return;
     } else {
-        await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+        await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
     }
 }

--- a/src/commands/ProtectionsCommands.ts
+++ b/src/commands/ProtectionsCommands.ts
@@ -23,14 +23,14 @@ import { isListSetting } from "../protections/ProtectionSettings";
 export async function execEnableProtection(roomId: string, event: any, mjolnir: Mjolnir, parts: string[]) {
     try {
         await mjolnir.protectionManager.enableProtection(parts[2]);
-        await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+        await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
     } catch (e) {
         LogService.error("ProtectionsCommands", extractRequestError(e));
 
         const message = `Error enabling protection '${parts[0]}' - check the name and try again.`;
         const reply = RichReply.createFor(roomId, event, message, message);
         reply["msgtype"] = "m.notice";
-        await mjolnir.client.sendMessage(roomId, reply);
+        await mjolnir.client.uncached.sendMessage(roomId, reply);
     }
 }
 
@@ -104,7 +104,7 @@ export async function execConfigSetProtection(roomId: string, event: any, mjolni
 
     const reply = RichReply.createFor(roomId, event, message, message);
     reply["msgtype"] = "m.notice";
-    await mjolnir.client.sendMessage(roomId, reply);
+    await mjolnir.client.uncached.sendMessage(roomId, reply);
 }
 
 /*
@@ -117,7 +117,7 @@ export async function execConfigAddProtection(roomId: string, event: any, mjolni
 
     const reply = RichReply.createFor(roomId, event, message, message);
     reply["msgtype"] = "m.notice";
-    await mjolnir.client.sendMessage(roomId, reply);
+    await mjolnir.client.uncached.sendMessage(roomId, reply);
 }
 
 /*
@@ -130,7 +130,7 @@ export async function execConfigRemoveProtection(roomId: string, event: any, mjo
 
     const reply = RichReply.createFor(roomId, event, message, message);
     reply["msgtype"] = "m.notice";
-    await mjolnir.client.sendMessage(roomId, reply);
+    await mjolnir.client.uncached.sendMessage(roomId, reply);
 }
 
 /*
@@ -151,7 +151,7 @@ export async function execConfigGetProtection(roomId: string, event: any, mjolni
             const errMsg = `Unknown protection: ${parts[0]}`;
             const errReply = RichReply.createFor(roomId, event, errMsg, errMsg);
             errReply["msgtype"] = "m.notice";
-            await mjolnir.client.sendMessage(roomId, errReply);
+            await mjolnir.client.uncached.sendMessage(roomId, errReply);
             return;
         }
         pickProtections = [parts[0]];
@@ -191,13 +191,13 @@ export async function execConfigGetProtection(roomId: string, event: any, mjolni
 
     const reply = RichReply.createFor(roomId, event, text, html);
     reply["msgtype"] = "m.notice";
-    await mjolnir.client.sendMessage(roomId, reply);
+    await mjolnir.client.uncached.sendMessage(roomId, reply);
 }
 
 // !mjolnir disable <protection>
 export async function execDisableProtection(roomId: string, event: any, mjolnir: Mjolnir, parts: string[]) {
     await mjolnir.protectionManager.disableProtection(parts[2]);
-    await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
 }
 
 // !mjolnir protections
@@ -217,5 +217,5 @@ export async function execListProtections(roomId: string, event: any, mjolnir: M
 
     const reply = RichReply.createFor(roomId, event, text, html);
     reply["msgtype"] = "m.notice";
-    await mjolnir.client.sendMessage(roomId, reply);
+    await mjolnir.client.uncached.sendMessage(roomId, reply);
 }

--- a/src/commands/RedactCommand.ts
+++ b/src/commands/RedactCommand.ts
@@ -24,7 +24,7 @@ export async function execRedactCommand(roomId: string, event: any, mjolnir: Mjo
     let roomAlias: string|null = null;
     let limit = Number.parseInt(parts.length > 3 ? parts[3] : "", 10); // default to NaN for later
     if (parts.length > 3 && isNaN(limit)) {
-        roomAlias = await mjolnir.client.resolveRoom(parts[3]);
+        roomAlias = await mjolnir.client.uncached.resolveRoom(parts[3]);
         if (parts.length > 4) {
             limit = Number.parseInt(parts[4], 10);
         }
@@ -33,21 +33,21 @@ export async function execRedactCommand(roomId: string, event: any, mjolnir: Mjo
     // Make sure we always have a limit set
     if (isNaN(limit)) limit = 1000;
 
-    const processingReactionId = await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], 'In Progress');
+    const processingReactionId = await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], 'In Progress');
 
     if (userId[0] !== '@') {
         // Assume it's a permalink
         const parsed = Permalinks.parseUrl(parts[2]);
-        const targetRoomId = await mjolnir.client.resolveRoom(parsed.roomIdOrAlias);
-        await mjolnir.client.redactEvent(targetRoomId, parsed.eventId);
-        await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
-        await mjolnir.client.redactEvent(roomId, processingReactionId, 'done processing command');
+        const targetRoomId = await mjolnir.client.uncached.resolveRoom(parsed.roomIdOrAlias);
+        await mjolnir.client.uncached.redactEvent(targetRoomId, parsed.eventId);
+        await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+        await mjolnir.client.uncached.redactEvent(roomId, processingReactionId, 'done processing command');
         return;
     }
 
     const targetRoomIds = roomAlias ? [roomAlias] : mjolnir.protectedRoomsTracker.getProtectedRooms();
     await redactUserMessagesIn(mjolnir.client, mjolnir.managementRoomOutput, userId, targetRoomIds, limit);
 
-    await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
-    await mjolnir.client.redactEvent(roomId, processingReactionId, 'done processing');
+    await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    await mjolnir.client.uncached.redactEvent(roomId, processingReactionId, 'done processing');
 }

--- a/src/commands/SetDefaultBanListCommand.ts
+++ b/src/commands/SetDefaultBanListCommand.ts
@@ -27,10 +27,10 @@ export async function execSetDefaultListCommand(roomId: string, event: any, mjol
         const replyText = "No ban list with that shortcode was found.";
         const reply = RichReply.createFor(roomId, event, replyText, replyText);
         reply["msgtype"] = "m.notice";
-        mjolnir.client.sendMessage(roomId, reply);
+        mjolnir.client.uncached.sendMessage(roomId, reply);
         return;
     }
 
-    await mjolnir.client.setAccountData(DEFAULT_LIST_EVENT_TYPE, { shortcode });
-    await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    await mjolnir.accountData.defaultList!.set({ shortcode });
+    await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
 }

--- a/src/commands/SetPowerLevelCommand.ts
+++ b/src/commands/SetPowerLevelCommand.ts
@@ -23,11 +23,11 @@ export async function execSetPowerLevelCommand(roomId: string, event: any, mjoln
     const level = Math.round(Number(parts[3]));
     const inRoom = parts[4];
 
-    let targetRooms = inRoom ? [await mjolnir.client.resolveRoom(inRoom)] : mjolnir.protectedRoomsTracker.getProtectedRooms();
+    let targetRooms = inRoom ? [await mjolnir.client.uncached.resolveRoom(inRoom)] : mjolnir.protectedRoomsTracker.getProtectedRooms();
 
     for (const targetRoomId of targetRooms) {
         try {
-            await mjolnir.client.setUserPowerLevel(victim, targetRoomId, level);
+            await mjolnir.client.uncached.setUserPowerLevel(victim, targetRoomId, level);
         } catch (e) {
             const message = e.message || (e.body ? e.body.error : '<no message>');
             await mjolnir.managementRoomOutput.logMessage(LogLevel.ERROR, "SetPowerLevelCommand", `Failed to set power level of ${victim} to ${level} in ${targetRoomId}: ${message}`, targetRoomId);
@@ -35,5 +35,5 @@ export async function execSetPowerLevelCommand(roomId: string, event: any, mjoln
         }
     }
 
-    await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
 }

--- a/src/commands/ShutdownRoomCommand.ts
+++ b/src/commands/ShutdownRoomCommand.ts
@@ -27,10 +27,10 @@ export async function execShutdownRoomCommand(roomId: string, event: any, mjolni
         const message = "I am not a Synapse administrator, or the endpoint is blocked";
         const reply = RichReply.createFor(roomId, event, message, message);
         reply['msgtype'] = "m.notice";
-        mjolnir.client.sendMessage(roomId, reply);
+        mjolnir.client.uncached.sendMessage(roomId, reply);
         return;
     }
 
-    await mjolnir.shutdownSynapseRoom(await mjolnir.client.resolveRoom(victim), reason);
-    await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    await mjolnir.shutdownSynapseRoom(await mjolnir.client.uncached.resolveRoom(victim), reason);
+    await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
 }

--- a/src/commands/StatusCommand.ts
+++ b/src/commands/StatusCommand.ts
@@ -86,7 +86,7 @@ async function showMjolnirStatus(roomId: string, event: any, mjolnir: Mjolnir) {
 
     const reply = RichReply.createFor(roomId, event, text, html);
     reply["msgtype"] = "m.notice";
-    return mjolnir.client.sendMessage(roomId, reply);
+    return mjolnir.client.uncached.sendMessage(roomId, reply);
 }
 
 async function showProtectionStatus(roomId: string, event: any, mjolnir: Mjolnir, parts: string[]) {
@@ -108,7 +108,7 @@ async function showProtectionStatus(roomId: string, event: any, mjolnir: Mjolnir
     }
     const reply = RichReply.createFor(roomId, event, text, html);
     reply["msgtype"] = "m.notice";
-    await mjolnir.client.sendMessage(roomId, reply);
+    await mjolnir.client.uncached.sendMessage(roomId, reply);
 }
 
 /**
@@ -149,7 +149,7 @@ async function showJoinsStatus(destinationRoomId: string, event: any, mjolnir: M
         const maxAgeHumanReadable = HUMANIZER.humanize(maxAgeMS, HUMANIZER_OPTIONS);
         let targetRoomId;
         try {
-            targetRoomId = await mjolnir.client.resolveRoom(targetRoomAliasOrId);
+            targetRoomId = await mjolnir.client.uncached.resolveRoom(targetRoomAliasOrId);
         } catch (ex) {
             return {
                 html: `Cannot resolve room ${htmlEscape(targetRoomAliasOrId)}.`,
@@ -171,6 +171,6 @@ async function showJoinsStatus(destinationRoomId: string, event: any, mjolnir: M
     })();
     const reply = RichReply.createFor(destinationRoomId, event, text, html);
     reply["msgtype"] = "m.notice";
-    return mjolnir.client.sendMessage(destinationRoomId, reply);
+    return mjolnir.client.uncached.sendMessage(destinationRoomId, reply);
 }
 

--- a/src/commands/WatchUnwatchCommand.ts
+++ b/src/commands/WatchUnwatchCommand.ts
@@ -24,10 +24,10 @@ export async function execWatchCommand(roomId: string, event: any, mjolnir: Mjol
         const replyText = "Cannot watch list due to error - is that a valid room alias?";
         const reply = RichReply.createFor(roomId, event, replyText, replyText);
         reply["msgtype"] = "m.notice";
-        mjolnir.client.sendMessage(roomId, reply);
+        mjolnir.client.uncached.sendMessage(roomId, reply);
         return;
     }
-    await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
 }
 
 // !mjolnir unwatch <room alias or ID>
@@ -37,8 +37,8 @@ export async function execUnwatchCommand(roomId: string, event: any, mjolnir: Mj
         const replyText = "Cannot unwatch list due to error - is that a valid room alias?";
         const reply = RichReply.createFor(roomId, event, replyText, replyText);
         reply["msgtype"] = "m.notice";
-        mjolnir.client.sendMessage(roomId, reply);
+        mjolnir.client.uncached.sendMessage(roomId, reply);
         return;
     }
-    await mjolnir.client.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
+    await mjolnir.client.uncached.unstableApis.addReactionToEvent(roomId, event['event_id'], '✅');
 }

--- a/src/protections/BasicFlooding.ts
+++ b/src/protections/BasicFlooding.ts
@@ -64,7 +64,7 @@ export class BasicFlooding extends Protection {
         if (messageCount >= this.settings.maxPerMinute.value) {
             await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "BasicFlooding", `Banning ${event['sender']} in ${roomId} for flooding (${messageCount} messages in the last minute)`, roomId);
             if (!mjolnir.config.noop) {
-                await mjolnir.client.banUser(event['sender'], roomId, "spam");
+                await mjolnir.client.uncached.banUser(event['sender'], roomId, "spam");
             } else {
                 await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "BasicFlooding", `Tried to ban ${event['sender']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
             }
@@ -76,7 +76,7 @@ export class BasicFlooding extends Protection {
             // Redact all the things the user said too
             if (!mjolnir.config.noop) {
                 for (const eventId of forUser.map(e => e.eventId)) {
-                    await mjolnir.client.redactEvent(roomId, eventId, "spam");
+                    await mjolnir.client.uncached.redactEvent(roomId, eventId, "spam");
                 }
             } else {
                 await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "BasicFlooding", `Tried to redact messages for ${event['sender']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);

--- a/src/protections/FirstMessageIsImage.ts
+++ b/src/protections/FirstMessageIsImage.ts
@@ -58,7 +58,7 @@ export class FirstMessageIsImage extends Protection {
             if (isMedia && this.justJoined[roomId].includes(event['sender'])) {
                 await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "FirstMessageIsImage", `Banning ${event['sender']} for posting an image as the first thing after joining in ${roomId}.`);
                 if (!mjolnir.config.noop) {
-                    await mjolnir.client.banUser(event['sender'], roomId, "spam");
+                    await mjolnir.client.uncached.banUser(event['sender'], roomId, "spam");
                 } else {
                     await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "FirstMessageIsImage", `Tried to ban ${event['sender']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
                 }
@@ -69,7 +69,7 @@ export class FirstMessageIsImage extends Protection {
 
                 // Redact the event
                 if (!mjolnir.config.noop) {
-                    await mjolnir.client.redactEvent(roomId, event['event_id'], "spam");
+                    await mjolnir.client.uncached.redactEvent(roomId, event['event_id'], "spam");
                 } else {
                     await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "FirstMessageIsImage", `Tried to redact ${event['event_id']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
                 }

--- a/src/protections/JoinWaveShortCircuit.ts
+++ b/src/protections/JoinWaveShortCircuit.ts
@@ -89,7 +89,7 @@ export class JoinWaveShortCircuit extends Protection {
             await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "JoinWaveShortCircuit", `Setting ${roomId} to invite-only as more than ${this.settings.maxPer.value} users have joined over the last ${this.settings.timescaleMinutes.value} minutes (since ${this.joinBuckets[roomId].lastBucketStart})`, roomId);
 
             if (!mjolnir.config.noop) {
-                await mjolnir.client.sendStateEvent(roomId, "m.room.join_rules", "", {"join_rule": "invite"})
+                await mjolnir.client.uncached.sendStateEvent(roomId, "m.room.join_rules", "", {"join_rule": "invite"})
             } else {
                 await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "JoinWaveShortCircuit", `Tried to set ${roomId} to invite-only, but Mjolnir is running in no-op mode`, roomId);
             }

--- a/src/protections/MessageIsMedia.ts
+++ b/src/protections/MessageIsMedia.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { Protection } from "./IProtection";
 import { Mjolnir } from "../Mjolnir";
-import { LogLevel, Permalinks, UserID } from "matrix-bot-sdk";
+import { LogLevel, Permalinks } from "matrix-bot-sdk";
 
 export class MessageIsMedia extends Protection {
 
@@ -40,10 +40,10 @@ export class MessageIsMedia extends Protection {
             const formattedBody = content['formatted_body'] || '';
             const isMedia = msgtype === 'm.image' || msgtype === 'm.video' || formattedBody.toLowerCase().includes('<img');
             if (isMedia) {
-                await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MessageIsMedia", `Redacting event from ${event['sender']} for posting an image/video. ${Permalinks.forEvent(roomId, event['event_id'], [new UserID(await mjolnir.client.getUserId()).domain])}`);
+                await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MessageIsMedia", `Redacting event from ${event['sender']} for posting an image/video. ${Permalinks.forEvent(roomId, event['event_id'], [mjolnir.client.domain])}`);
                 // Redact the event
                 if (!mjolnir.config.noop) {
-                    await mjolnir.client.redactEvent(roomId, event['event_id'], "Images/videos are not permitted here");
+                    await mjolnir.client.uncached.redactEvent(roomId, event['event_id'], "Images/videos are not permitted here");
                 } else {
                     await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MessageIsMedia", `Tried to redact ${event['event_id']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
                 }

--- a/src/protections/MessageIsVoice.ts
+++ b/src/protections/MessageIsVoice.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { Protection } from "./IProtection";
 import { Mjolnir } from "../Mjolnir";
-import { LogLevel, Permalinks, UserID } from "matrix-bot-sdk";
+import { LogLevel, Permalinks } from "matrix-bot-sdk";
 
 export class MessageIsVoice extends Protection {
 
@@ -37,10 +37,10 @@ export class MessageIsVoice extends Protection {
         if (event['type'] === 'm.room.message' && event['content']) {
             if (event['content']['msgtype'] !== 'm.audio') return;
             if (event['content']['org.matrix.msc3245.voice'] === undefined) return;
-            await mjolnir.managementRoomOutput.logMessage(LogLevel.INFO, "MessageIsVoice", `Redacting event from ${event['sender']} for posting a voice message. ${Permalinks.forEvent(roomId, event['event_id'], [new UserID(await mjolnir.client.getUserId()).domain])}`);
+            await mjolnir.managementRoomOutput.logMessage(LogLevel.INFO, "MessageIsVoice", `Redacting event from ${event['sender']} for posting a voice message. ${Permalinks.forEvent(roomId, event['event_id'], [mjolnir.client.domain])}`);
             // Redact the event
             if (!mjolnir.config.noop) {
-                await mjolnir.client.redactEvent(roomId, event['event_id'], "Voice messages are not permitted here");
+                await mjolnir.client.uncached.redactEvent(roomId, event['event_id'], "Voice messages are not permitted here");
             } else {
                 await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MessageIsVoice", `Tried to redact ${event['event_id']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
             }

--- a/src/protections/TrustedReporters.ts
+++ b/src/protections/TrustedReporters.ts
@@ -73,16 +73,16 @@ export class TrustedReporters extends Protection {
         }
         if (reporters.size === this.settings.redactThreshold.value) {
             met.push("redact");
-            await mjolnir.client.redactEvent(roomId, event.id, "abuse detected");
+            await mjolnir.client.uncached.redactEvent(roomId, event.id, "abuse detected");
         }
         if (reporters.size === this.settings.banThreshold.value) {
             met.push("ban");
-            await mjolnir.client.banUser(event.userId, roomId, "abuse detected");
+            await mjolnir.client.uncached.banUser(event.userId, roomId, "abuse detected");
         }
 
 
         if (met.length > 0) {
-            await mjolnir.client.sendMessage(mjolnir.config.managementRoom, {
+            await mjolnir.client.uncached.sendMessage(mjolnir.config.managementRoom, {
                 msgtype: "m.notice",
                 body: `message ${event.id} reported by ${[...reporters].join(', ')}. `
                     + `actions: ${met.join(', ')}`

--- a/src/queues/EventRedactionQueue.ts
+++ b/src/queues/EventRedactionQueue.ts
@@ -13,11 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { LogLevel, MatrixClient } from "matrix-bot-sdk"
+import { LogLevel } from "matrix-bot-sdk"
 import { ERROR_KIND_FATAL } from "../ErrorCache";
 import { RoomUpdateError } from "../models/RoomUpdateError";
 import { redactUserMessagesIn } from "../utils";
 import ManagementRoomOutput from "../ManagementRoomOutput";
+import { CachingClient } from "../CachingClient";
 
 export interface QueuedRedaction {
     /** The room which the redaction will take place in. */
@@ -27,7 +28,7 @@ export interface QueuedRedaction {
      * Called by the EventRedactionQueue.
      * @param client A MatrixClient to use to carry out the redaction.
      */
-    redact(client: MatrixClient, managementRoom: ManagementRoomOutput): Promise<void>
+    redact(client: CachingClient, managementRoom: ManagementRoomOutput): Promise<void>
     /**
      * Used to test whether the redaction is the equivalent to another redaction.
      * @param redaction Another QueuedRedaction to test if this redaction is an equivalent to.
@@ -47,7 +48,7 @@ export class RedactUserInRoom implements QueuedRedaction {
         this.roomId = roomId;
     }
 
-    public async redact(client: MatrixClient, managementRoom: ManagementRoomOutput) {
+    public async redact(client: CachingClient, managementRoom: ManagementRoomOutput) {
         await managementRoom.logMessage(LogLevel.DEBUG, "Mjolnir", `Redacting events from ${this.userId} in room ${this.roomId}.`);
         await redactUserMessagesIn(client, managementRoom, this.userId, [this.roomId]);
     }
@@ -107,7 +108,7 @@ export class EventRedactionQueue {
      * @param limitToRoomId If the roomId is provided, only redactions for that room will be processed.
      * @returns A description of any errors encountered by each QueuedRedaction that was processed.
      */
-    public async process(client: MatrixClient, managementRoom: ManagementRoomOutput, limitToRoomId?: string): Promise<RoomUpdateError[]> {
+    public async process(client: CachingClient, managementRoom: ManagementRoomOutput, limitToRoomId?: string): Promise<RoomUpdateError[]> {
         const errors: RoomUpdateError[] = [];
         const redact = async (currentBatch: QueuedRedaction[]) => {
             for (const redaction of currentBatch) {

--- a/src/queues/UnlistedUserRedactionQueue.ts
+++ b/src/queues/UnlistedUserRedactionQueue.ts
@@ -43,7 +43,7 @@ export class UnlistedUserRedactionQueue {
             try {
                 LogService.info("AutomaticRedactionQueue", `Redacting event because the user is listed as bad: ${permalink}`)
                 if (!mjolnir.config.noop) {
-                    await mjolnir.client.redactEvent(roomId, event['event_id']);
+                    await mjolnir.client.uncached.redactEvent(roomId, event['event_id']);
                 } else {
                     await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "AutomaticRedactionQueue", `Tried to redact ${permalink} but Mjolnir is running in no-op mode`);
                 }


### PR DESCRIPTION
This is a first attempt to add a minimal layer of caching on top of `MatrixClient`.

The objective is to reduce the amount of calls to the homeserver, plus gain performance. Some auditing shows that we place *lots* of calls that are simply useless because we are calling to request data that we already have.

The general idea is that:

- we now cache the user id, localpart, domain in a single place (previously, it was cached in many places, uncached in many more);
- code can request a cache for specific account data types (previously, very little of it was cached);
- in the future, I'd like to expand this with the ability to request a cache for specific state events in specific rooms (at the moment, none of it is cached afaict).

Just caching the user id should already visibly reduce the amount of requests that we perform.