### PR TITLE
Mention flood protection

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -178,6 +178,9 @@ protections:
     # (users will always be banned if they say a bad word)
     minutesBeforeTrusting: 20
 
+  mentionflood:
+    minutesBeforeTrusting: 20
+
 # Options for advanced monitoring of the health of the bot.
 health:
   # healthz options. These options are best for use in container environments

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,6 +74,9 @@ export interface IConfig {
             words: string[];
             minutesBeforeTrusting: number;
         };
+        mentionflood: {
+            minutesBeforeTrusting: number;
+        };
     };
     health: {
         healthz: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -144,6 +144,9 @@ const defaultConfig: IConfig = {
         wordlist: {
             words: [],
             minutesBeforeTrusting: 20
+        },
+        mentionflood: {
+            minutesBeforeTrusting: 20
         }
     },
     health: {

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -47,7 +47,7 @@ export class MentionFlood extends Protection {
                 await mjolnir.client.banUser(event['sender'], `Banning ${event['sender']} for mention flood in ${roomId}`);
                 await mjolnir.client.redactEvent(roomId, event['event_id'], "spam");
             } else {
-                await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MentionFlood", `Tried to ban ${event['sender']} for mention flood in ${roomId} but Mjolnir is running in no-op mode.`)
+                await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MentionFlood", `Tried to ban ${event['sender']} for mention flood in ${roomId} but Mjolnir is running in no-op mode.`);
             }
         }
     }

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -1,0 +1,54 @@
+import { Protection } from './IProtection';
+import { NumberProtectionSetting } from './ProtectionSettings';
+import { Mjolnir } from '../Mjolnir';
+import { LogLevel } from 'matrix-bot-sdk';
+
+// We ban user if they mention more or equal to this ratio
+export const DEFAULT_MAX_MENTIONS = 5;
+
+// Default regexes
+const LOCALPART_REGEX = "[0-9a-z-.=_/]+";
+const DOMAIN_REGEX = "(\\b((?=[a-z0-9-]{1,63}\\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,63}\\b)";
+const IPV4_REGEX = "(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))";
+const IPV6_REGEX = "(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))";
+const PORT_REGEX = "(:[0-9]+)?";
+
+export class MentionFlood extends Protection {
+    settings = {
+        maxMentions: new NumberProtectionSetting(DEFAULT_MAX_MENTIONS)
+    };
+
+    private mention: RegExp;
+
+    constructor() {
+        super();
+        this.mention = new RegExp(`@${LOCALPART_REGEX}:(${DOMAIN_REGEX}|${IPV4_REGEX}|${IPV6_REGEX})${PORT_REGEX}`, "gi");
+    }
+
+    public get name(): string {
+        return 'MentionFloodProtection';
+    }
+
+    public get description(): string {
+        return `If an user tries to mention more than ${DEFAULT_MAX_MENTIONS} people, it will ban them automatically. This does not publish the ban to any of your ban lists.`;
+    }
+
+    public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any> {
+        const content = event['content'] || {};
+
+        if (event['type'] !== 'm.room.message') return;
+
+        const message: string = content['formatted_body'] || content['body'] || '';
+
+        const maxMentionsPerMessage = this.settings.maxMentions.value;
+        if (message && (message.match(this.mention)?.length || 0) > maxMentionsPerMessage) {
+            await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MentionFlood", `Banning ${event['sender']}`);
+            if (!mjolnir.config.noop) {
+                await mjolnir.client.banUser(event['sender'], `Banning ${event['sender']} for mention flood in ${roomId}`);
+                await mjolnir.client.redactEvent(roomId, event['event_id'], "spam");
+            } else {
+                await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MentionFlood", `Tried to ban ${event['sender']} for mention flood in ${roomId} but Mjolnir is running in no-op mode.`)
+            }
+        }
+    }
+}

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -37,7 +37,6 @@ export class MentionFlood extends Protection {
             if (!this.justJoined[roomId]) this.justJoined[roomId] = {};
             if (event['type'] === 'm.room.member') {
                 if (isTrueJoinEvent(event)) {
-                    const now = new Date();
                     this.justJoined[roomId][event['state_key']] = now;
                     LogService.info("WordList", `${event['state_key']} joined ${roomId} at ${now.toDateString()}`);
                 } else if (content['membership'] === 'leave' || content['membership'] === 'ban') {

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -38,7 +38,7 @@ export class MentionFlood extends Protection {
             if (event['type'] === 'm.room.member') {
                 if (isTrueJoinEvent(event)) {
                     this.justJoined[roomId][event['state_key']] = now;
-                    LogService.info("WordList", `${event['state_key']} joined ${roomId} at ${now.toDateString()}`);
+                    LogService.info("MentionFlood", `${event['state_key']} joined ${roomId} at ${now.toDateString()}`);
                 } else if (content['membership'] === 'leave' || content['membership'] === 'ban') {
                     delete this.justJoined[roomId][event['sender']];
                 }
@@ -55,7 +55,7 @@ export class MentionFlood extends Protection {
             if (joinTime) {
                 if (now.valueOf() - joinTime.valueOf() > minsBeforeTrusting * 60 * 1000) {
                     delete this.justJoined[roomId][event['sender']];
-                    LogService.info("WordList", `${event['sender']} is no longer considered suspect`);
+                    LogService.info("MentionFlood", `${event['sender']} is no longer considered suspect`);
                     return;
                 }
 

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -7,24 +7,15 @@ import { isTrueJoinEvent } from '../utils';
 // We ban user if they mention more or equal to this ratio
 export const DEFAULT_MAX_MENTIONS = 5;
 
-// Default regexes
-const LOCALPART_REGEX = "[0-9a-z-.=_/]+";
-const DOMAIN_REGEX = "(\\b((?=[a-z0-9-]{1,63}\\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,63}\\b)";
-const IPV4_REGEX = "(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))";
-const IPV6_REGEX = "(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))";
-const PORT_REGEX = "(:[0-9]+)?";
-
 export class MentionFlood extends Protection {
     settings = {
         maxMentions: new NumberProtectionSetting(DEFAULT_MAX_MENTIONS)
     };
 
     private justJoined: { [roomId: string]: { [username: string]: Date } } = {};
-    private mention: RegExp;
 
     constructor() {
         super();
-        this.mention = new RegExp(`@${LOCALPART_REGEX}:(${DOMAIN_REGEX}|${IPV4_REGEX}|${IPV6_REGEX})${PORT_REGEX}`, "gi");
     }
 
     public get name(): string {
@@ -59,12 +50,8 @@ export class MentionFlood extends Protection {
 
         const message: string = content['formatted_body'] || content['body'] || null;
 
-        if (minsBeforeTrusting < 0) return;
-        const joinTime = this.justJoined[roomId][event['sender']]
-        if ((joinTime && (now.valueOf() - joinTime.valueOf() > minsBeforeTrusting * 60 * 1000)) || !joinTime) return;
-
         const maxMentionsPerMessage = this.settings.maxMentions.value;
-        if (message && (message.match(this.mention)?.length || 0) > maxMentionsPerMessage) {
+        if (message && (message.match(/@[^:]*:\S+/gi)?.length || 0) > maxMentionsPerMessage) {
             await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MentionFlood", `Banning ${event['sender']}`);
             if (!mjolnir.config.noop) {
                 await mjolnir.client.banUser(event['sender'], `Banning ${event['sender']} for mention flood in ${roomId}`);

--- a/src/protections/MentionFlood.ts
+++ b/src/protections/MentionFlood.ts
@@ -2,6 +2,7 @@ import { Protection } from './IProtection';
 import { NumberProtectionSetting } from './ProtectionSettings';
 import { Mjolnir } from '../Mjolnir';
 import { LogLevel, LogService } from 'matrix-bot-sdk';
+import { isTrueJoinEvent } from '../utils';
 
 // We ban user if they mention more or equal to this ratio
 export const DEFAULT_MAX_MENTIONS = 5;
@@ -40,7 +41,7 @@ export class MentionFlood extends Protection {
         const now = new Date();
 
         if (minsBeforeTrusting > 0) {
-            if (!this.justJoined[roomId]) this.justJoined[roo] = {};
+            if (!this.justJoined[roomId]) this.justJoined[roomId] = {};
 
             if (event['type'] === 'm.room.member') {
                 if (isTrueJoinEvent(event)) {

--- a/src/protections/ProtectionManager.ts
+++ b/src/protections/ProtectionManager.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { FirstMessageIsImage } from "./FirstMessageIsImage";
 import { Protection } from "./IProtection";
 import { BasicFlooding } from "./BasicFlooding";
+import { MentionFlood } from "./MentionFlood";
 import { DetectFederationLag } from "./DetectFederationLag";
 import { WordList } from "./WordList";
 import { MessageIsVoice } from "./MessageIsVoice";
@@ -34,6 +35,7 @@ import { RoomUpdateError } from "../models/RoomUpdateError";
 const PROTECTIONS: Protection[] = [
     new FirstMessageIsImage(),
     new BasicFlooding(),
+    new MentionFlood(),
     new WordList(),
     new MessageIsVoice(),
     new MessageIsMedia(),

--- a/test/integration/protectionSettingsTest.ts
+++ b/test/integration/protectionSettingsTest.ts
@@ -23,6 +23,13 @@ describe("Test: Protection settings", function() {
             ProtectionSettingValidationError
         );
     });
+    it("Mjolnir refuses to save invalid protection setting values", async function() {
+        this.timeout(20000);
+        await assert.rejects(
+            async () => await this.mjolnir.protectionManager.setProtectionSettings("MentionFloodProtection", {"maxMentions": "beep"}),
+            ProtectionSettingValidationError
+        );
+    });
     it("Mjolnir successfully saves valid protection setting values", async function() {
         this.timeout(20000);
 


### PR DESCRIPTION
Fixes: https://github.com/matrix-org/mjolnir/issues/211, https://github.com/matrix-org/mjolnir/issues/309

Implemented that because I need it somewhere.

## Additions

This PR adds support for the `MentionFloodProtection`.  
When activated, if a user tries to spam mentions (on default `5` per message), they will be banned and the message redacted.  
There is also a grace period that is by default on 20 minutes. After that, the user will be able to mention as much people as they want.

## Tests

+ `yarn lint` ✅
+ `yarn test` ✅
+ `yarn test:integration` ✅

## Screenshots

![image](https://user-images.githubusercontent.com/76598503/193741917-856e7c5a-ddaa-4456-b72c-d6686336f282.png)
![image](https://user-images.githubusercontent.com/76598503/193741964-da1a09ee-239d-4f4f-9355-b0cb75c9540d.png)


---

Signed-off-by: Jae Lo Presti <jae.lopresti@futurice.com>