### PR TITLE
CI: Let's try and cache mx-tester installs

### DIFF
--- a/.github/workflows/mjolnir.yml
+++ b/.github/workflows/mjolnir.yml
@@ -43,11 +43,16 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: '16'
-    - name: install mx-tester
-      run: cargo install mx-tester
+    - name: Fetch and build mx-tester (cached across runs)
+      uses: baptiste0928/cargo-install@v1
+      with:
+        crate: mx-tester
+        version: "0.3.3"
     - name: Setup image
-      run: RUST_LOG=debug mx-tester build up
+      run: RUST_LOG=debug,hyper=info,rusttls=info mx-tester build up
     - name: Setup dependencies
       run: yarn install
     - name: Run tests
-      run: RUST_LOG=debug mx-tester run
+      run: RUST_LOG=debug,hyper=info,rusttls=info mx-tester run
+    - name: Cleanup
+      run: mx-tester down


### PR DESCRIPTION
mx-tester takes several minutes to install and that's a shame. Let's see if we can cache it across runs.