### PR TITLE
Refactor list creation with MSC3784 support.

### DIFF
--- a/src/commands/CreateBanListCommand.ts
+++ b/src/commands/CreateBanListCommand.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { Mjolnir } from "../Mjolnir";
-import { SHORTCODE_EVENT_TYPE } from "../models/PolicyList";
+import PolicyList from "../models/PolicyList";
 import { Permalinks, RichReply } from "matrix-bot-sdk";
 
 // !mjolnir list create <shortcode> <alias localpart>
@@ -23,34 +23,12 @@ export async function execCreateListCommand(roomId: string, event: any, mjolnir:
     const shortcode = parts[3];
     const aliasLocalpart = parts[4];
 
-    const powerLevels: { [key: string]: any } = {
-        "ban": 50,
-        "events": {
-            "m.room.name": 100,
-            "m.room.power_levels": 100,
-        },
-        "events_default": 50, // non-default
-        "invite": 0,
-        "kick": 50,
-        "notifications": {
-            "room": 20,
-        },
-        "redact": 50,
-        "state_default": 50,
-        "users": {
-            [await mjolnir.client.getUserId()]: 100,
-            [event["sender"]]: 50
-        },
-        "users_default": 0,
-    };
-
-    const listRoomId = await mjolnir.client.createRoom({
-        preset: "public_chat",
-        room_alias_name: aliasLocalpart,
-        invite: [event['sender']],
-        initial_state: [{ type: SHORTCODE_EVENT_TYPE, state_key: "", content: { shortcode: shortcode } }],
-        power_level_content_override: powerLevels,
-    });
+    const listRoomId = await PolicyList.createList(
+        mjolnir.client,
+        shortcode,
+        [event['sender']],
+        { room_alias_name: aliasLocalpart }
+    );
 
     const roomRef = Permalinks.forRoom(listRoomId);
     await mjolnir.watchList(roomRef);

--- a/test/integration/banListTest.ts
+++ b/test/integration/banListTest.ts
@@ -8,6 +8,7 @@ import { getMessagesByUserIn } from "../../src/utils";
 import { Mjolnir } from "../../src/Mjolnir";
 import { ALL_RULE_TYPES, Recommendation, RULE_SERVER, RULE_USER, SERVER_RULE_TYPES } from "../../src/models/ListRule";
 import AccessControlUnit, { Access, EntityAccess } from "../../src/models/AccessControlUnit";
+import { randomUUID } from "crypto";
 
 /**
  * Create a policy rule in a policy room.
@@ -562,5 +563,33 @@ describe('Test: AccessControlUnit interaction with policy lists.', function() {
         await removePolicyRule(mjolnir.client, policyLists[1].roomId, RULE_SERVER, banMeServer);
         await Promise.all(policyLists.map(list => list.updateList()));
         assertAccess(Access.Allowed, aclUnit.getAccessForServer(banMeServer), "Should not longer be any rules");
+    })
+})
+
+describe('Test: Creating policy lists.', function() {
+    it('Will automatically invite and op users from invites', async function() {
+        const mjolnir: Mjolnir = this.mjolnir;
+        const testUsers = await Promise.all([...Array(2)].map(_ => newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } })))
+        const invite = await Promise.all(testUsers.map(client => client.getUserId()));
+        const policyListId = await PolicyList.createList(
+            mjolnir.client,
+            randomUUID(),
+            invite
+        );
+        // Check power levels are right.
+        const powerLevelEvent = await mjolnir.client.getRoomStateEvent(policyListId, "m.room.power_levels", "");
+        assert.equal(Object.keys(powerLevelEvent.users ?? {}).length, invite.length + 1);
+        // Check create event for MSC3784 support.
+        const createEvent = await mjolnir.client.getRoomStateEvent(policyListId, "m.room.create", "");
+        assert.equal(createEvent.type, PolicyList.ROOM_TYPE);
+        // We can't create rooms without forgetting the type.
+        await assert.rejects(
+            async () => {
+                await PolicyList.createList(mjolnir.client, randomUUID(), [], {
+                    creation_content: {}
+                })
+            },
+            TypeError
+        );
     })
 })


### PR DESCRIPTION
https://github.com/matrix-org/matrix-spec-proposals/pull/3784

This was extracted from the appservice mjolnir work to reduce review burden.

The idea behind supporting MSC3784 is that clients can start to provide UX for editing policy lists directly rather than going through Mjolinr commands.