### PR TITLE
Update selfbuld docs to explicitly provide config and not rely on implicit behavior from previous version.

### DIFF
--- a/docs/setup_selfbuild.md
+++ b/docs/setup_selfbuild.md
@@ -1,4 +1,5 @@
-To build mjolnir, you have to have installed `yarn` 1.x and Node 16.
+These instructions are to build and run mjolnir without using [Docker](./setup_docker.md).
+You need to have installed `yarn` 1.x and Node 16.
 
 ```bash
 git clone https://github.com/matrix-org/mjolnir.git
@@ -7,9 +8,10 @@ cd mjolnir
 yarn install
 yarn build
 
-# Copy and edit the config. It *is* recommended to change the data path.
-cp config/default.yaml config/development.yaml
-nano config/development.yaml
+# Copy and edit the config. It *is* recommended to change the data path,
+# as this is set to `/data` by default for dockerized mjolnir.
+cp config/default.yaml config/production.yaml
+nano config/production.yaml
 
-node lib/index.js
+NODE_ENV=production node lib/index.js
 ```


### PR DESCRIPTION
The package we used to load config in the past, `node-config`, would default to `development`.
https://github.com/node-config/node-config/blob/f54b41990095c2b340ae129dfd8f623da1dfa20d/lib/config.js#L561 https://github.com/matrix-org/mjolnir/pull/347