### PR TITLE
Stop Mjolnir blindly protecting all policy lists at startup.

### DIFF
--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -291,8 +291,10 @@ export class Mjolnir {
             await this.protectedRoomsConfig.loadProtectedRoomsFromConfig(this.config);
             await this.protectedRoomsConfig.loadProtectedRoomsFromAccountData();
             this.protectedRoomsConfig.getExplicitlyProtectedRooms().forEach(this.protectRoom, this);
-            await this.resyncJoinedRooms(false);
+            // We have to build the policy lists before calling `resyncJoinedRooms` otherwise mjolnir will try to protect
+            // every policy list we are already joined to, as mjolnir will not be able to distinguish them from normal rooms.
             await this.buildWatchedPolicyLists();
+            await this.resyncJoinedRooms(false);
             await this.protectionManager.start();
 
             if (this.config.verifyPermissionsOnStartup) {


### PR DESCRIPTION
`Mjolnir.resyncAllJoinedRooms` needs policy lists to be loaded into mjolnir in order to filter them out of the protect rooms set (unless explicitly protected). This is so that you don't end up having mjolnir complain about protecting a list which you have no control over, and are just watching (e.g. #matrix-org-coc-bl:matrix.org).

https://matrix.to/#/!WpbOWAblxueZXAAnjj:matrix.org/$f0rKGBOJTcaC_bLPfydApg8oUEw4caZNk-9G1Sa4QSU?via=matrix.org&via=envs.net&via=element.io