### PR TITLE
Config fixes

### DIFF
--- a/docs/setup_docker.md
+++ b/docs/setup_docker.md
@@ -25,7 +25,7 @@ In short, please make sure that the mjolnir configuration exists under `./config
 Run the following command in your terminal, replace `./mjolnir` with the root directory of your config, if it is in another spot.
 
 ```bash
-docker run --rm -it -v ./mjolnir:/data matrixdotorg/mjolnir:latest
+docker run --rm -it -v ./mjolnir:/data matrixdotorg/mjolnir:latest bot --mjolnir-config /data/config/production.yaml
 ```
 
 # Docker Compose

--- a/docs/setup_selfbuild.md
+++ b/docs/setup_selfbuild.md
@@ -13,5 +13,5 @@ yarn build
 cp config/default.yaml config/production.yaml
 nano config/production.yaml
 
-NODE_ENV=production node lib/index.js
+node lib/index.js --mjolnir-config ./config/production.yaml
 ```

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "version": "sed -i '/# version automated/s/[0-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*/'$npm_package_version'/' synapse_antispam/setup.py && git add synapse_antispam/setup.py && cat synapse_antispam/setup.py"
   },
   "devDependencies": {
+    "@types/config": "^3.3.0",
     "@types/crypto-js": "^4.0.2",
     "@types/express": "^4.17.13",
     "@types/html-to-text": "^8.0.1",
@@ -43,6 +44,7 @@
   "dependencies": {
     "await-lock": "^2.2.2",
     "body-parser": "^1.20.1",
+    "config": "^3.3.8",
     "express": "^4.17",
     "html-to-text": "^8.0.0",
     "humanize-duration": "^3.27.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { load } from "js-yaml";
 import { MatrixClient } from "matrix-bot-sdk";
+import Config from "config";
 
 /**
  * The configuration, as read from production.yaml
@@ -171,11 +172,6 @@ const defaultConfig: IConfig = {
 };
 
 export function read(): IConfig {
-    const config_dir = process.env.NODE_CONFIG_DIR || "./config";
-    const config_file = `${process.env.NODE_ENV || "default"}.yaml`
-
-    const content = fs.readFileSync(path.join(config_dir, config_file), "utf8");
-    const parsed = load(content);
-    const config = {...defaultConfig, ...(parsed as object)} as IConfig;
+    const config = Config.util.extendDeep({}, defaultConfig, Config.util.toObject()) as IConfig;
     return config;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,6 +122,11 @@
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
   integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
 
+"@types/config@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@types/config/-/config-3.3.0.tgz#2b632cb37c639bf8d57054561f5a77d31dcebc1e"
+  integrity sha512-9kZSbl3/X3TVNowLCu5HFQdQmD+4287Om55avknEYkuo6R2dDrsp/EXEHUFvfYeG7m1eJ0WYGj+cbcUIhARJAQ==
+
 "@types/connect@*":
   version "3.4.35"
   resolved "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz"
@@ -775,6 +780,13 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+config@^3.3.8:
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/config/-/config-3.3.8.tgz#14ef7aef22af25877fdaee696ec64d761feb7be0"
+  integrity sha512-rFzF6VESOdp7wAXFlB9IOZI4ouL05g3A03v2eRcTHj2JBQaTNJ40zhAUl5wRbWHqLZ+uqp/7OE0BWWtAVgrong==
+  dependencies:
+    json5 "^2.2.1"
 
 content-disposition@0.5.3:
   version "0.5.3"
@@ -2051,6 +2063,11 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+json5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
+  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
 jsonpointer@^5.0.0:
   version "5.0.1"


### PR DESCRIPTION

##### Use the npm package config to load the config

This is what was used prior to https://github.com/matrix-org/mjolnir/pull/347.
It was a nice idea motivated to drop a dependency that was confusing.
It was just never followed through and was underestimated how much disruption it would cause.
It was also believed that the library would mean there could only ever be one global copy of the config,
It was followed up by:
https://github.com/matrix-org/mjolnir/pull/369
https://github.com/matrix-org/mjolnir/pull/357
https://github.com/matrix-org/mjolnir/pull/429
https://github.com/matrix-org/mjolnir/pull/397
https://github.com/matrix-org/mjolnir/issues/365

For simplicity sake I am reinstating the library.
The practice of loading default.yaml by default is also dangerous
and has led to issues multiple times in #mjolnir:matrix.org.
It is a sample and not a default.

##### Add cli argument for the config

`--mjolnir-config` can be specified to give a path to the config.
The reason it uses mjolnir as a prefix is so it cannot be confused with the appservice arguments.
The documentation has been updated accordingly so that people use that instead of relying on the implicit environment variable behaviour.