### PR TITLE
Refactor how we listen for matrix events.

### DIFF
--- a/src/MatrixEmitter.ts
+++ b/src/MatrixEmitter.ts
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import EventEmitter from "events";
-import { MatrixClient } from "matrix-bot-sdk";
 
 /**
  * This is an interface created in order to keep the event listener
@@ -43,25 +42,4 @@ export declare interface MatrixEmitter extends EventEmitter {
 
     start(): Promise<void>;
     stop(): void;
-}
-
-// Blruh are you dumb? is this even needed??
-export class MatrixClientListner extends EventEmitter implements MatrixEmitter {
-    constructor(private readonly client: MatrixClient) {
-        super();
-        const makeListener = (event: string) => {
-            return (...args: any[]) => this.emit(event, ...args);
-        };
-        for (const event of ['room.event', 'room.messages', 'room.invite', 'room.join', 'room.leave']) {
-            this.client.on(event, makeListener(event));
-        }
-    }
-
-    public async start(): Promise<void> {
-        await this.client.start();
-    }
-
-    public stop(): void {
-        this.client.stop();
-    }
 }

--- a/src/MatrixEmitter.ts
+++ b/src/MatrixEmitter.ts
@@ -1,0 +1,67 @@
+/*
+Copyright 2019-2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import EventEmitter from "events";
+import { MatrixClient } from "matrix-bot-sdk";
+
+/**
+ * This is an interface created in order to keep the event listener
+ * Mjolnir uses for new events generic. This is because events
+ * can come from `/sync` if we are in bot mode or from the appservice.
+ */
+export declare interface MatrixEmitter extends EventEmitter {
+    on(event: 'room.event', listener: (roomId: string, mxEvent: any) => void ): this
+    emit(event: 'room.event', roomId: string, mxEvent: any): boolean
+
+    on(event: 'room.message', listener: (roomId: string, mxEvent: any) => void ): this
+    emit(event: 'room.message', roomId: string, mxEvent: any): boolean
+
+    on(event: 'room.invite', listener: (roomId: string, mxEvent: any) => void ): this
+    emit(event: 'room.invite', roomId: string, mxEvent: any): boolean
+
+    on(event: 'room.join', listener: (roomId: string, mxEvent: any) => void ): this
+    emit(event: 'room.join', roomId: string, mxEvent: any): boolean
+
+    on(event: 'room.leave', listener: (roomId: string, mxEvent: any) => void ): this
+    emit(event: 'room.leave', roomId: string, mxEvent: any): boolean
+
+    on(event: 'room.archived', listener: (roomId: string, mxEvent: any) => void ): this
+    emit(event: 'room.archived', roomId: string, mxEvent: any): boolean
+
+    start(): Promise<void>;
+    stop(): void;
+}
+
+// Blruh are you dumb? is this even needed??
+export class MatrixClientListner extends EventEmitter implements MatrixEmitter {
+    constructor(private readonly client: MatrixClient) {
+        super();
+        const makeListener = (event: string) => {
+            return (...args: any[]) => this.emit(event, ...args);
+        };
+        for (const event of ['room.event', 'room.messages', 'room.invite', 'room.join', 'room.leave']) {
+            this.client.on(event, makeListener(event));
+        }
+    }
+
+    public async start(): Promise<void> {
+        await this.client.start();
+    }
+
+    public stop(): void {
+        this.client.stop();
+    }
+}

--- a/src/RoomMembers.ts
+++ b/src/RoomMembers.ts
@@ -1,4 +1,4 @@
-import { MatrixClient } from "matrix-bot-sdk";
+import { MatrixEmitter } from "./MatrixEmitter";
 
 enum Action {
     Join,
@@ -154,7 +154,7 @@ class RoomMembers {
 export class RoomMemberManager {
     private perRoom: Map<string /* room id */, RoomMembers> = new Map();
     private readonly cbHandleEvent;
-    constructor(private client: MatrixClient) {
+    constructor(private client: MatrixEmitter) {
         // Listen for join events.
         this.cbHandleEvent = this.handleEvent.bind(this);
         client.on("room.event", this.cbHandleEvent);

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ import { initializeSentry, patchMatrixClient } from "./utils";
         patchMatrixClient();
         config.RUNTIME.client = client;
 
-        bot = await Mjolnir.setupMjolnirFromConfig(client, config);
+        bot = await Mjolnir.setupMjolnirFromConfig(client, client, config);
     } catch (err) {
         console.error(`Failed to setup mjolnir from the config ${config.dataPath}: ${err}`);
         throw err;

--- a/src/protections/ProtectionManager.ts
+++ b/src/protections/ProtectionManager.ts
@@ -64,7 +64,7 @@ export class ProtectionManager {
      */
     public async start() {
         this.mjolnir.reportManager.on("report.new", this.handleReport.bind(this));
-        this.mjolnir.client.on("room.event", this.handleEvent.bind(this));
+        this.mjolnir.matrixEmitter.on("room.event", this.handleEvent.bind(this));
         for (const protection of PROTECTIONS) {
             try {
                 await this.registerProtection(protection);

--- a/src/report/ReportManager.ts
+++ b/src/report/ReportManager.ts
@@ -79,7 +79,7 @@ export class ReportManager extends EventEmitter {
     constructor(public mjolnir: Mjolnir) {
         super();
         // Configure bot interactions.
-        mjolnir.client.on("room.event", async (roomId, event) => {
+        mjolnir.matrixEmitter.on("room.event", async (roomId, event) => {
             try {
                 switch (event["type"]) {
                     case "m.reaction": {

--- a/test/integration/mjolnirSetupUtils.ts
+++ b/test/integration/mjolnirSetupUtils.ts
@@ -84,7 +84,7 @@ export async function makeMjolnir(config: IConfig): Promise<Mjolnir> {
     await overrideRatelimitForUser(config.homeserverUrl, await client.getUserId());
     patchMatrixClient();
     await ensureAliasedRoomExists(client, config.managementRoom);
-    let mj = await Mjolnir.setupMjolnirFromConfig(client, config);
+    let mj = await Mjolnir.setupMjolnirFromConfig(client, client, config);
     globalClient = client;
     globalMjolnir = mj;
     return mj;


### PR DESCRIPTION
closes https://github.com/matrix-org/mjolnir/issues/411.

Issue https://github.com/matrix-org/mjolnir/issues/411 says that we have to be careful about room.join,
but this was before we figured how to make matrix-appservice-bridge
echo events sent by its own intents.

Also fixes a persistence bug where if the appservice is restarted, the mjolnirs won't be protecting or watching any rooms.
Also makes mjolnir respond to `!mjolnir status` correctly in the appservice.