### PR TITLE
Make `updateForEvent` actually update PolicyLists.

### DIFF
--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -436,7 +436,6 @@ export class Mjolnir {
     private async addPolicyList(roomId: string, roomRef: string): Promise<PolicyList> {
         const list = new PolicyList(roomId, roomRef, this.client);
         this.ruleServer?.watch(list);
-        list.on('PolicyList.batch', (...args) => this.protectedRoomsTracker.syncWithPolicyList(...args));
         await list.updateList();
         this.policyLists.push(list);
         this.protectedRoomsTracker.watchList(list);


### PR DESCRIPTION
For some reason we were relying on a mjolnir listening to `'PolicyList.batch'` to update policy lists.

This was exposing an implementation detail to Mjolnir and including it as part of the implementation of
`PolicyList.updateForEvent()` which is supposed to cause the `PolicyList` to update (eventually).

I am confident this was because of a need before batching was introduced to get the changes to a policy list directly from the method call to `PolicyList.update()`, whereas now you can just listen to `PolicyList.update`.

The `'PolicyList.batch'` event has now been removed and the PolicyList event batcher (`UpdateBatcher`) now calls `PolicyList.update()` internally.