### PR TITLE
Make `autojoinOnlyIfManager` true by default.

### DIFF
--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -31,7 +31,7 @@ import { ReportPoller } from "./report/ReportPoller";
 import { WebAPIs } from "./webapis/WebAPIs";
 import RuleServer from "./models/RuleServer";
 import { ThrottlingQueue } from "./queues/ThrottlingQueue";
-import { IConfig } from "./config";
+import { getDefaultConfig, IConfig } from "./config";
 import PolicyList from "./models/PolicyList";
 import { ProtectedRoomsSet } from "./ProtectedRoomsSet";
 import ManagementRoomOutput from "./ManagementRoomOutput";
@@ -140,6 +140,9 @@ export class Mjolnir {
      * @returns A new Mjolnir instance that can be started without further setup.
      */
     static async setupMjolnirFromConfig(client: MatrixSendClient, matrixEmitter: MatrixEmitter, config: IConfig): Promise<Mjolnir> {
+        if (!config.autojoinOnlyIfManager && config.acceptInvitesFromSpace === getDefaultConfig().acceptInvitesFromSpace) {
+            throw new TypeError("`autojoinOnlyIfManager` has been disabled, yet no space has been provided for `acceptInvitesFromSpace`.");
+        }
         const policyLists: PolicyList[] = [];
         const joinedRooms = await client.getJoinedRooms();
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,8 +37,13 @@ export interface IConfig {
         password: string;
     };
     dataPath: string;
-    acceptInvitesFromSpace: string;
+    /**
+     * If true, Mjolnir will only accept invites from users present in managementRoom.
+     * Otherwise a space must be provided to `acceptInvitesFromSpace`.
+     */
     autojoinOnlyIfManager: boolean;
+    /** Mjolnir will accept invites from members of this space if `autojoinOnlyIfManager` is false. */
+    acceptInvitesFromSpace: string;
     recordIgnoredInvites: boolean;
     managementRoom: string;
     verboseLogging: boolean;
@@ -127,7 +132,7 @@ const defaultConfig: IConfig = {
     },
     dataPath: "/data/storage",
     acceptInvitesFromSpace: '!noop:example.org',
-    autojoinOnlyIfManager: false,
+    autojoinOnlyIfManager: true,
     recordIgnoredInvites: false,
     managementRoom: "!noop:example.org",
     verboseLogging: false,


### PR DESCRIPTION
Also assert that we if `autojoinOnlyIfManager` is enabled that
the user has provided a space for `acceptInvitesFromSpace`.
It does sound like `autojoinOnlyIfManager` would imply that
anyone could send an invitation to the mjolnir if
`autojoinOnlyIfManager` is false.
This has never been the case though, and it is not sensible
either, especially if `protectAllJoinedRooms` is also true.
Additionally the documentation in `config/default.yaml`
has always claimed that `autojoinOnlyIfManager` is "true by default".

This setting has confused users in #mjolnir:matrix.org before
Closes https://github.com/matrix-org/mjolnir/issues/436.

Also fixes an issue in the appservice where we require
`autojoinOnlyIfManager` to always be explicitly set to false
or it crashes any Mjolnir receiving an invite.