### PR TITLE
A look at `PolicyList.update` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "parse-duration": "^1.0.2",
     "pg": "^8.8.0",
     "shell-quote": "^1.7.3",
+    "ulidx": "^0.3.0",
     "yaml": "^2.1.1"
   },
   "engines": {

--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -302,7 +302,7 @@ export class Mjolnir {
 
             if (this.config.verifyPermissionsOnStartup) {
                 await this.managementRoomOutput.logMessage(LogLevel.INFO, "Mjolnir@startup", "Checking permissions...");
-                await this.protectedRoomsTracker.verifyPermissions(this.config.verboseLogging);
+                await this.protectedRoomsTracker.verifyPermissions();
             }
 
             // Start the bot.
@@ -311,7 +311,7 @@ export class Mjolnir {
             this.currentState = STATE_SYNCING;
             if (this.config.syncOnStartup) {
                 await this.managementRoomOutput.logMessage(LogLevel.INFO, "Mjolnir@startup", "Syncing lists...");
-                await this.protectedRoomsTracker.syncLists(this.config.verboseLogging);
+                await this.protectedRoomsTracker.syncLists();
             }
 
             this.currentState = STATE_RUNNING;
@@ -426,7 +426,7 @@ export class Mjolnir {
         }
 
         if (withSync) {
-            await this.protectedRoomsTracker.syncLists(this.config.verboseLogging);
+            await this.protectedRoomsTracker.syncLists();
         }
     }
 

--- a/src/ProtectedRoomsSet.ts
+++ b/src/ProtectedRoomsSet.ts
@@ -92,7 +92,12 @@ export class ProtectedRoomsSet {
      * Intended to be `this.syncWithUpdatedPolicyList` so we can add it in `this.watchList` and remove it in `this.unwatchList`.
      * Otherwise we would risk being informed about lists we no longer watch.
      */
-    private readonly listUpdateListener: (list: PolicyList, changes: ListRuleChange[]) => void;
+    private readonly listUpdateListener: (list: PolicyList, changes: ListRuleChange[], revisionId: string) => void;
+
+    /**
+     * The revision of a each watched list that we have applied to protected rooms.
+     */
+    private readonly listRevisions = new Map<PolicyList, /** The last revision we used to sync protected rooms. */ string>();
 
     constructor(
         private readonly client: MatrixSendClient,
@@ -210,15 +215,9 @@ export class ProtectedRoomsSet {
     }
 
     /**
-     * Sync all the rooms with all the watched lists, banning and applying any changed ACLS.
-     * @param verbose Whether to report any errors to the management room.
+     * Synchronize all the protected rooms with all of the policies described in the watched policy lists.
      */
-    public async syncLists(verbose = true) {
-        for (const list of this.policyLists) {
-            const changes = await list.updateList();
-            await this.printBanlistChanges(changes, list);
-        }
-
+    public async syncRoomsWithPolicies() {
         let hadErrors = false;
         const [aclErrors, banErrors] = await Promise.all([
             this.applyServerAcls(this.policyLists, this.protectedRoomsByActivity()),
@@ -229,7 +228,7 @@ export class ProtectedRoomsSet {
         hadErrors = hadErrors || await this.printActionResult(banErrors, "Errors updating member bans:");
         hadErrors = hadErrors || await this.printActionResult(redactionErrors, "Error updating redactions:");
 
-        if (!hadErrors && verbose) {
+        if (!hadErrors) {
             const html = `<font color="#00cc00">Done updating rooms - no errors</font>`;
             const text = "Done updating rooms - no errors";
             await this.client.sendMessage(this.managementRoomId, {
@@ -239,6 +238,21 @@ export class ProtectedRoomsSet {
                 formatted_body: html,
             });
         }
+    }
+
+    /**
+     * Sync all the rooms with all the watched lists, banning and applying any changed ACLS.
+     */
+    public async syncLists() {
+        for (const list of this.policyLists) {
+            const { revisionId } = await list.updateList();
+            const previousRevision = this.listRevisions.get(list);
+            if (previousRevision === undefined || revisionId > previousRevision) {
+                this.listRevisions.set(list, revisionId);
+                // we rely `this.listUpdateListener` to print the changes to the list.
+            }
+        }
+        await this.syncRoomsWithPolicies();
     }
 
     public addProtectedRoom(roomId: string): void {
@@ -263,28 +277,15 @@ export class ProtectedRoomsSet {
      * @param policyList The `PolicyList` which we will check for changes and apply them to all protected rooms.
      * @returns When all of the protected rooms have been updated.
      */
-    private async syncWithUpdatedPolicyList(policyList: PolicyList, changes: ListRuleChange[]): Promise<void> {
-        let hadErrors = false;
-        const [aclErrors, banErrors] = await Promise.all([
-            this.applyServerAcls(this.policyLists, this.protectedRoomsByActivity()),
-            this.applyUserBans(this.protectedRoomsByActivity())
-        ]);
-        const redactionErrors = await this.processRedactionQueue();
-        hadErrors = hadErrors || await this.printActionResult(aclErrors, "Errors updating server ACLs:");
-        hadErrors = hadErrors || await this.printActionResult(banErrors, "Errors updating member bans:");
-        hadErrors = hadErrors || await this.printActionResult(redactionErrors, "Error updating redactions:");
-
-        if (!hadErrors) {
-            const html = `<font color="#00cc00"><b>Done updating rooms - no errors</b></font>`;
-            const text = "Done updating rooms - no errors";
-            await this.client.sendMessage(this.managementRoomId, {
-                msgtype: "m.notice",
-                body: text,
-                format: "org.matrix.custom.html",
-                formatted_body: html,
-            });
+    private async syncWithUpdatedPolicyList(policyList: PolicyList, changes: ListRuleChange[], revisionId: string): Promise<void> {
+        // avoid resyncing the rooms if we have already done so for the latest revision of this list.
+        const previousRevision = this.listRevisions.get(policyList);
+        if (previousRevision === undefined || revisionId > previousRevision) {
+            this.listRevisions.set(policyList, revisionId);
+            await this.syncRoomsWithPolicies();
         }
         // This can fail if the change is very large and it is much less important than applying bans, so do it last.
+        // We always print changes because we make this listener responsible for doing it.
         await this.printBanlistChanges(changes, policyList);
     }
 

--- a/src/commands/SyncCommand.ts
+++ b/src/commands/SyncCommand.ts
@@ -18,5 +18,5 @@ import { Mjolnir } from "../Mjolnir";
 
 // !mjolnir sync
 export async function execSyncCommand(roomId: string, event: any, mjolnir: Mjolnir) {
-    return mjolnir.protectedRoomsTracker.syncLists(mjolnir.config.verboseLogging);
+    return mjolnir.protectedRoomsTracker.syncLists();
 }

--- a/src/commands/UnbanBanCommand.ts
+++ b/src/commands/UnbanBanCommand.ts
@@ -155,7 +155,7 @@ export async function execUnbanCommand(roomId: string, event: any, mjolnir: Mjol
 
         if (unbannedSomeone) {
             await mjolnir.managementRoomOutput.logMessage(LogLevel.DEBUG, "UnbanBanCommand", `Syncing lists to ensure no users were accidentally unbanned`);
-            await mjolnir.protectedRoomsTracker.syncLists(mjolnir.config.verboseLogging);
+            await mjolnir.protectedRoomsTracker.syncLists();
         }
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2146,6 +2146,11 @@ kuler@^2.0.0:
   resolved "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz"
   integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
 
+layerr@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/layerr/-/layerr-0.1.2.tgz#16c8e7fb042d3595ab15492bdad088f31d7afd15"
+  integrity sha512-ob5kTd9H3S4GOG2nVXyQhOu9O8nBgP555XxWPkJI0tR0JeRilfyTp8WtPdIJHLXBmHMSdEq5+KMxiYABeScsIQ==
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz"
@@ -3573,6 +3578,13 @@ typescript@^4.8.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+
+ulidx@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ulidx/-/ulidx-0.3.0.tgz#19899adb2d8c57d4f6d598ab63da9164634a5251"
+  integrity sha512-Qvpa2xAzS6fBUpiqHSHWvn6XiSLCAPyNDDz035vsEWmUoXRqC4c9JySLIfdBuK0N1xGBxng6GHDOZgyNQfxAHg==
+  dependencies:
+    layerr "^0.1.2"
 
 underscore@~1.4.4:
   version "1.4.4"


### PR DESCRIPTION
This started out as just a way to find out why mjolnir was syncing with lists several times for each update to a policy list.

The main changes are

- Verbosity was irrelevant to the sync command but for some reason was an option.
  Unfortunately all this did was suppress whether to tell you when it had finished, meaning it wouldn't
  when verbose logging was disabled. Historically this was probably a parameter that got passed through
  to applyServerAcl/applyUserBans, which can be horribly verbose, but they access the config directly.

- Stop emitting `'PolicyList.update'` when there are no changes.
- Include a revision ID for the `'PolicyList.update'`method and event.
- Use the revision ID in the `ProtectedRoomsSet` so that we don't unnecessarily resynchronize all rooms when the `'PolicyList.update'` event is received. Though not when the `sync` command is used. Since this is supposed to `sync` in the case when there is a state reset or otherwise or the user has changed some room settings.
- insert an await lock around the `PolicyList.update` method to avoid a race condition where a call can be started and finished within the extent of an existing call (via another task, this can happen if the server is slow with handling one request). `PolicyList.udpate` now has a helper that is synchronous to be called directly after requesting the room state. The reason for this is to enforce that no one `await`s while updating the policy list's cache of rules.
- The revision ID uses a ULID, but this is unnecessary and could have just been a "dumb counter".

closes https://github.com/matrix-org/mjolnir/issues/447