### PR TITLE
A first implementation of report-to-moderator

### DIFF
--- a/mx-tester.yml
+++ b/mx-tester.yml
@@ -75,3 +75,19 @@ homeserver:
     remote:
       per_second: 10000
       burst_count: 10000
+
+# Creating a few users simplifies testing.
+users:
+  - localname: admin
+    admin: true
+    rooms:
+      - public: true
+        name: "List of users"
+        alias: access-control-list
+        members:
+          - admin
+          - user_in_mjolnir_for_all
+  # This user can use Mjölnir-for-all
+  - localname: user_in_mjolnir_for_all
+  # This user cannot
+  - localname: user_regular

--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -116,7 +116,7 @@ export class Mjolnir {
             if (options.autojoinOnlyIfManager) {
                 const managers = await client.getJoinedRoomMembers(mjolnir.managementRoomId);
                 if (!managers.includes(membershipEvent.sender)) return reportInvite(); // ignore invite
-            } else {
+            } else if (options.acceptInvitesFromSpace) {
                 const spaceId = await client.resolveRoom(options.acceptInvitesFromSpace);
                 const spaceUserIds = await client.getJoinedRoomMembers(spaceId)
                     .catch(async e => {
@@ -141,7 +141,7 @@ export class Mjolnir {
      */
     static async setupMjolnirFromConfig(client: MatrixSendClient, matrixEmitter: MatrixEmitter, config: IConfig): Promise<Mjolnir> {
         if (!config.autojoinOnlyIfManager && config.acceptInvitesFromSpace === getDefaultConfig().acceptInvitesFromSpace) {
-            throw new TypeError("`autojoinOnlyIfManager` has been disabled, yet no space has been provided for `acceptInvitesFromSpace`.");
+            throw new TypeError("`autojoinOnlyIfManager` has been disabled but you have not set `acceptInvitesFromSpace`. Please make it empty to accept invites from everywhere or give it a namespace alias or room id.");
         }
         const joinedRooms = await client.getJoinedRooms();
 

--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -243,8 +243,13 @@ export class Mjolnir {
         this.protectionManager = new ProtectionManager(this);
 
         this.managementRoomOutput = new ManagementRoomOutput(managementRoomId, client, config);
-        const protections = new ProtectionManager(this);
-        this.protectedRoomsTracker = new ProtectedRoomsSet(client, clientUserId, managementRoomId, this.managementRoomOutput, protections, config);
+        this.protectedRoomsTracker = new ProtectedRoomsSet(
+            client,
+            clientUserId,
+            managementRoomId,
+            this.managementRoomOutput,
+            this.protectionManager,
+            config);
     }
 
     public get state(): string {

--- a/src/ProtectedRoomsSet.ts
+++ b/src/ProtectedRoomsSet.ts
@@ -104,12 +104,6 @@ export class ProtectedRoomsSet {
         private readonly clientUserId: string,
         private readonly managementRoomId: string,
         private readonly managementRoomOutput: ManagementRoomOutput,
-        /**
-         * The protection manager is only used to verify the permissions
-         * that the protection manager requires are correct for this set of rooms.
-         * The protection manager is not really compatible with this abstraction yet
-         * because of a direct dependency on the protection manager in Mjolnir commands.
-         */
         private readonly protectionManager: ProtectionManager,
         private readonly config: IConfig,
     ) {
@@ -264,11 +258,13 @@ export class ProtectedRoomsSet {
         }
         this.protectedRooms.add(roomId);
         this.protectedRoomActivityTracker.addProtectedRoom(roomId);
+        this.protectionManager.addProtectedRoom(roomId);
     }
 
     public removeProtectedRoom(roomId: string): void {
         this.protectedRoomActivityTracker.removeProtectedRoom(roomId);
         this.protectedRooms.delete(roomId);
+        this.protectionManager.removeProtectedRoom(roomId);
     }
 
     /**

--- a/src/appservice/Api.ts
+++ b/src/appservice/Api.ts
@@ -154,9 +154,9 @@ export class Api {
 
         // TODO: provisionNewMjolnir will throw if it fails...
         // https://github.com/matrix-org/mjolnir/issues/408
-        const [mjolnirId, managementRoom] = await this.mjolnirManager.provisionNewMjolnir(userId);
+        const mjolnir = await this.mjolnirManager.provisionNewMjolnir(userId);
 
-        response.status(200).json({ mxid: mjolnirId, roomId: managementRoom });
+        response.status(200).json({ mxid: await mjolnir.getUserId(), roomId: mjolnir.managementRoomId });
     }
 
     /**

--- a/src/appservice/MjolnirManager.ts
+++ b/src/appservice/MjolnirManager.ts
@@ -65,8 +65,8 @@ export class MjolnirManager {
             intentListener,
         );
         await managedMjolnir.start();
-        if (this.config.displayName) {
-            await client.setDisplayName(this.config.displayName);
+        if (this.config.bot.displayName) {
+            await client.setDisplayName(this.config.bot.displayName);
         }
         this.perMjolnirId.set(mjolnirUserId, managedMjolnir);
         this.perOwnerId.set(requestingUserId, managedMjolnir);

--- a/src/appservice/config/config.example.yaml
+++ b/src/appservice/config/config.example.yaml
@@ -17,3 +17,7 @@ accessControlList: "#access-control-list:localhost:9999"
 # This is a web api that the widget connects to in order to interact with the appservice.
 webAPI:
   port: 9001
+
+bot:
+  # The display name of the bot
+  displayName: Moderation bot

--- a/src/appservice/config/config.harness.yaml
+++ b/src/appservice/config/config.harness.yaml
@@ -11,3 +11,6 @@ accessControlList: "#access-control-list:localhost:9999"
 
 webAPI:
   port: 9001
+
+bot:
+  displayName: Moderation bot

--- a/src/appservice/config/config.ts
+++ b/src/appservice/config/config.ts
@@ -74,12 +74,17 @@ export interface IConfig {
              */
             address: string;
         }
-    }
+    },
+    /** a display name */
+    displayName?: string,
 }
 
 export function read(configPath: string): IConfig {
     const content = fs.readFileSync(configPath, "utf8");
     const parsed = load(content);
     const config = (parsed as object) as IConfig;
+    if (!config.displayName) {
+        config.displayName = "Moderation Bot";
+    }
     return config;
 }

--- a/src/appservice/config/config.ts
+++ b/src/appservice/config/config.ts
@@ -75,16 +75,21 @@ export interface IConfig {
             address: string;
         }
     },
-    /** a display name */
-    displayName?: string,
+    bot: {
+        /** a display name */
+        displayName?: string,
+    },
 }
 
 export function read(configPath: string): IConfig {
     const content = fs.readFileSync(configPath, "utf8");
     const parsed = load(content);
     const config = (parsed as object) as IConfig;
-    if (!config.displayName) {
-        config.displayName = "Moderation Bot";
+    if (!config.bot) {
+        config.bot = {};
+    }
+    if (!config.bot.displayName) {
+        config.bot.displayName = "Moderation Bot";
     }
     return config;
 }

--- a/src/commands/CommandHandler.ts
+++ b/src/commands/CommandHandler.ts
@@ -42,6 +42,7 @@ import { execKickCommand } from "./KickCommand";
 import { execMakeRoomAdminCommand } from "./MakeRoomAdminCommand";
 import { parse as tokenize } from "shell-quote";
 import { execSinceCommand } from "./SinceCommand";
+import { execSetupProtectedRoom } from "./SetupDecentralizedReportingCommand";
 
 
 export const COMMAND_PREFIX = "!mjolnir";
@@ -101,6 +102,8 @@ export async function handleCommand(roomId: string, event: { content: { body: st
             return await execAddProtectedRoom(roomId, event, mjolnir, parts);
         } else if (parts[1] === 'rooms' && parts.length > 3 && parts[2] === 'remove') {
             return await execRemoveProtectedRoom(roomId, event, mjolnir, parts);
+        } else if (parts[1] === 'rooms' && parts.length > 3 && parts[2] === 'setup') {
+            return await execSetupProtectedRoom(roomId, event, mjolnir, parts);
         } else if (parts[1] === 'rooms' && parts.length === 2) {
             return await execListProtectedRooms(roomId, event, mjolnir);
         } else if (parts[1] === 'move' && parts.length > 3) {
@@ -156,6 +159,7 @@ export async function handleCommand(roomId: string, event: { content: { body: st
                 "!mjolnir rooms                                                      - Lists all the protected rooms\n" +
                 "!mjolnir rooms add <room alias/ID>                                  - Adds a protected room (may cause high server load)\n" +
                 "!mjolnir rooms remove <room alias/ID>                               - Removes a protected room\n" +
+                "!mjolnir rooms setup <room alias/ID> reporting                      - Setup decentralized reporting in a room\n" +
                 "!mjolnir move <room alias> <room alias/ID>                          - Moves a <room alias> to a new <room ID>\n" +
                 "!mjolnir directory add <room alias/ID>                              - Publishes a room in the server's room directory\n" +
                 "!mjolnir directory remove <room alias/ID>                           - Removes a room from the server's room directory\n" +

--- a/src/commands/SetupDecentralizedReportingCommand.ts
+++ b/src/commands/SetupDecentralizedReportingCommand.ts
@@ -1,0 +1,61 @@
+import { Mjolnir } from "../Mjolnir";
+import { LogLevel } from "matrix-bot-sdk";
+
+const EVENT_MODERATED_BY = "org.matrix.msc3215.room.moderation.moderated_by";
+const EVENT_MODERATOR_OF = "org.matrix.msc3215.room.moderation.moderator_of";
+
+// !mjolnir rooms setup <room alias/ID> reporting
+export async function execSetupProtectedRoom(commandRoomId: string, event: any, mjolnir: Mjolnir, parts: string[]) {
+    // For the moment, we only accept a subcommand `reporting`.
+    if (parts[4] !== 'reporting') {
+        await mjolnir.client.sendNotice(commandRoomId, "Invalid subcommand for `rooms setup <room alias/ID> subcommand`, expected one of \"reporting\"");
+        await mjolnir.client.unstableApis.addReactionToEvent(commandRoomId, event['event_id'], '❌');
+        return;
+    }
+    const protectedRoomId = await mjolnir.client.joinRoom(parts[3]);
+
+    try {
+        const userId = await mjolnir.client.getUserId();
+
+        // A backup of the previous state in case we need to rollback.
+        let previousState: /* previous content */ any | /* there was no previous content */ null;
+        try {
+            previousState = await mjolnir.client.getRoomStateEvent(protectedRoomId, EVENT_MODERATED_BY, EVENT_MODERATED_BY);
+        } catch (ex) {
+            previousState = null;
+        }
+
+        // Setup protected room -> moderation room link.
+        // We do this before the other one to be able to fail early if we do not have a sufficient
+        // powerlevel.
+        let eventId = await mjolnir.client.sendStateEvent(protectedRoomId, EVENT_MODERATED_BY, EVENT_MODERATED_BY, {
+            room_id: commandRoomId,
+            user_id: userId,
+        });
+
+        try {
+            // Setup moderation room -> protected room.
+            await mjolnir.client.sendStateEvent(commandRoomId, EVENT_MODERATOR_OF, protectedRoomId, {
+                user_id: userId,
+            });
+        } catch (ex) {
+            // If the second `sendStateEvent` fails, we could end up with a room half setup, which
+            // is bad. Attempt to rollback.
+            try {
+                if (previousState) {
+                    await mjolnir.client.sendStateEvent(protectedRoomId, EVENT_MODERATED_BY, EVENT_MODERATED_BY, previousState);
+                } else {
+                    await mjolnir.client.redactEvent(protectedRoomId, eventId, "Rolling back incomplete MSC3215 setup");
+                }
+            } finally {
+                // Ignore second exception
+                throw ex;
+            }
+        }
+
+    } catch (ex) {
+        mjolnir.managementRoomOutput.logMessage(LogLevel.ERROR, "execSetupProtectedRoom", ex.message);
+        await mjolnir.client.unstableApis.addReactionToEvent(commandRoomId, event['event_id'], '❌');
+    }
+    await mjolnir.client.unstableApis.addReactionToEvent(commandRoomId, event['event_id'], '✅');
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -322,5 +322,9 @@ export function getProvisionedMjolnirConfig(managementRoomId: string): IConfig {
 
     config.managementRoom = managementRoomId;
     config.protectedRooms = [];
+
+    // Configure Mjölnir to accept invites automatically (necessary for requesting moderation)
+    config.autojoinOnlyIfManager = false;
+    config.acceptInvitesFromSpace = "";
     return config;
 }

--- a/src/protections/IProtection.ts
+++ b/src/protections/IProtection.ts
@@ -31,11 +31,26 @@ export abstract class Protection {
     readonly requiredStatePermissions: string[] = [];
     abstract settings: { [setting: string]: AbstractProtectionSetting<any, any> };
 
+    /**
+     * A new room has been added to the list of rooms to protect with this protection.
+     */
+    async startProtectingRoom(mjolnir: Mjolnir, roomId: string) {
+        // By default, do nothing.
+    }
+
+    /**
+     * A room has been removed from the list of rooms to protect with this protection.
+     */
+    async stopProtectingRoom(mjolnir: Mjolnir, roomId: string) {
+        // By default, do nothing.
+    }
+
     /*
      * Handle a single event from a protected room, to decide if we need to
      * respond to it
      */
     async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<Consequence[] | any> {
+        // By default, do nothing.
     }
 
     /*
@@ -43,6 +58,7 @@ export abstract class Protection {
      * need to respond to it
      */
     async handleReport(mjolnir: Mjolnir, roomId: string, reporterId: string, event: any, reason?: string): Promise<any> {
+        // By default, do nothing.
     }
 
     /**

--- a/src/protections/LocalAbuseReports.ts
+++ b/src/protections/LocalAbuseReports.ts
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 Element.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { LogLevel } from "matrix-bot-sdk";
+import { Mjolnir } from "../Mjolnir";
+import { Protection } from "./IProtection";
+
+/*
+    An implementation of per decentralized abuse reports, as per
+    https://github.com/Yoric/matrix-doc/blob/aristotle/proposals/3215-towards-decentralized-moderation.md
+ */
+
+const EVENT_MODERATED_BY = "org.matrix.msc3215.room.moderation.moderated_by";
+const EVENT_MODERATOR_OF = "org.matrix.msc3215.room.moderation.moderator_of";
+
+/**
+ * Setup decentralized abuse reports in protected rooms.
+ */
+export class LocalAbuseReports extends Protection {
+    settings: { };
+    public readonly name = "LocalAbuseReports";
+    public readonly description = "Enables MSC3215-compliant web clients to send abuse reports to the moderator instead of the homeserver admin";
+    readonly requiredStatePermissions = [EVENT_MODERATED_BY];
+
+    /**
+     * A new room has been added to the list of rooms to protect with this protection.
+     */
+    async startProtectingRoom(mjolnir: Mjolnir, protectedRoomId: string) {
+        try {
+            const userId = await mjolnir.client.getUserId();
+
+            // Fetch the previous state of the room, to avoid overwriting any existing setup.
+            let previousState: /* previous content */ any | /* there was no previous content */ null;
+            try {
+                previousState = await mjolnir.client.getRoomStateEvent(protectedRoomId, EVENT_MODERATED_BY, EVENT_MODERATED_BY);
+            } catch (ex) {
+                previousState = null;
+            }
+            if (previousState && previousState["room_id"] && previousState["user_id"]) {
+                if (previousState["room_id"] === mjolnir.managementRoomId && previousState["user_id"] === userId) {
+                    // The room is already setup, do nothing.
+                    return;
+                } else {
+                    // There is a setup already, but it's not for us. Don't overwrite it.
+                    let protectedRoomAliasOrId = await mjolnir.client.getPublishedAlias(protectedRoomId) || protectedRoomId;
+                    mjolnir.managementRoomOutput.logMessage(LogLevel.INFO, "LocalAbuseReports", `Room ${protectedRoomAliasOrId} is already setup for decentralized abuse reports with bot ${previousState["user_id"]} and room ${previousState["room_id"]}, not overwriting automatically. To overwrite, use command \`!mjolnir rooms setup ${protectedRoomId} reporting\``);
+                    return;
+                }
+            }
+
+            // Setup protected room -> moderation room link.
+            // We do this before the other one to be able to fail early if we do not have a sufficient
+            // powerlevel.
+            let eventId;
+            try {
+                eventId = await mjolnir.client.sendStateEvent(protectedRoomId, EVENT_MODERATED_BY, EVENT_MODERATED_BY, {
+                    room_id: mjolnir.managementRoomId,
+                    user_id: userId,
+                });
+            } catch (ex) {
+                mjolnir.managementRoomOutput.logMessage(LogLevel.ERROR, "LocalAbuseReports", `Could not autoset protected room -> moderation room link: ${ex.message}. To set it manually, use command \`!mjolnir rooms setup ${protectedRoomId} reporting\``);
+                return;
+            }
+
+            try {
+                // Setup moderation room -> protected room.
+                await mjolnir.client.sendStateEvent(mjolnir.managementRoomId, EVENT_MODERATOR_OF, protectedRoomId, {
+                    user_id: userId,
+                });
+            } catch (ex) {
+                // If the second `sendStateEvent` fails, we could end up with a room half setup, which
+                // is bad. Attempt to rollback.
+                mjolnir.managementRoomOutput.logMessage(LogLevel.ERROR, "LocalAbuseReports", `Could not autoset moderation room -> protected room link: ${ex.message}. To set it manually, use command \`!mjolnir rooms setup ${protectedRoomId} reporting\``);
+                try {
+                    await mjolnir.client.redactEvent(protectedRoomId, eventId, "Rolling back incomplete MSC3215 setup");
+                } finally {
+                    // Ignore second exception, propagate first.
+                    throw ex;
+                }
+            }
+        } catch (ex) {
+            mjolnir.managementRoomOutput.logMessage(LogLevel.ERROR, "LocalAbuseReports", ex.message);
+        }
+    }
+}

--- a/src/protections/ProtectionManager.ts
+++ b/src/protections/ProtectionManager.ts
@@ -30,6 +30,7 @@ import { Consequence } from "./consequence";
 import { htmlEscape } from "../utils";
 import { ERROR_KIND_FATAL, ERROR_KIND_PERMISSION } from "../ErrorCache";
 import { RoomUpdateError } from "../models/RoomUpdateError";
+import { LocalAbuseReports } from "./LocalAbuseReports";
 
 const PROTECTIONS: Protection[] = [
     new FirstMessageIsImage(),
@@ -40,6 +41,7 @@ const PROTECTIONS: Protection[] = [
     new TrustedReporters(),
     new DetectFederationLag(),
     new JoinWaveShortCircuit(),
+    new LocalAbuseReports(),
 ];
 
 const ENABLED_PROTECTIONS_EVENT_TYPE = "org.matrix.mjolnir.enabled_protections";
@@ -97,6 +99,11 @@ export class ProtectionManager {
             // this.getProtectionSettings() validates this data for us, so we don't need to
             protection.settings[key].setValue(value);
         }
+        if (protection.enabled) {
+            for (let roomId of this.mjolnir.protectedRoomsTracker.getProtectedRooms()) {
+                await protection.startProtectingRoom(this.mjolnir, roomId);
+            }
+        }
     }
 
     /*
@@ -104,11 +111,17 @@ export class ProtectionManager {
      *
      * @param protection The protection object we want to unregister
      */
-    public unregisterProtection(protectionName: string) {
-        if (!(this._protections.has(protectionName))) {
+    public async unregisterProtection(protectionName: string) {
+        let protection = this._protections.get(protectionName);
+        if (!protection) {
             throw new Error("Failed to find protection by name: " + protectionName);
         }
         this._protections.delete(protectionName);
+        if (protection.enabled) {
+            for (let roomId of this.mjolnir.protectedRoomsTracker.getProtectedRooms()) {
+                await protection.stopProtectingRoom(this.mjolnir, roomId);
+            }
+        }
     }
 
     /*
@@ -159,9 +172,13 @@ export class ProtectionManager {
      */
     public async enableProtection(name: string) {
         const protection = this._protections.get(name);
-        if (protection !== undefined) {
-            protection.enabled = true;
-            await this.saveEnabledProtections();
+        if (protection === undefined) {
+            return;
+        }
+        protection.enabled = true;
+        await this.saveEnabledProtections();
+        for (let roomId of this.mjolnir.protectedRoomsTracker.getProtectedRooms()) {
+            await protection.startProtectingRoom(this.mjolnir, roomId);
         }
     }
 
@@ -187,9 +204,13 @@ export class ProtectionManager {
      */
     public async disableProtection(name: string) {
         const protection = this._protections.get(name);
-        if (protection !== undefined) {
-            protection.enabled = false;
-            await this.saveEnabledProtections();
+        if (protection === undefined) {
+            return;
+        }
+        protection.enabled = false;
+        await this.saveEnabledProtections();
+        for (let roomId of this.mjolnir.protectedRoomsTracker.getProtectedRooms()) {
+            await protection.stopProtectingRoom(this.mjolnir, roomId);
         }
     }
 
@@ -392,6 +413,26 @@ export class ProtectionManager {
     private async handleReport({ roomId, reporterId, event, reason }: { roomId: string, reporterId: string, event: any, reason?: string }) {
         for (const protection of this.enabledProtections) {
             await protection.handleReport(this.mjolnir, roomId, reporterId, event, reason);
+        }
+    }
+
+    public async addProtectedRoom(roomId: string) {
+        for (const protection of this.enabledProtections) {
+            try {
+                await protection.startProtectingRoom(this.mjolnir, roomId);
+            } catch (ex) {
+                this.mjolnir.managementRoomOutput.logMessage(LogLevel.ERROR, protection.name, ex);
+            }
+        }
+    }
+
+    public async removeProtectedRoom(roomId: string) {
+        for (const protection of this.enabledProtections) {
+            try {
+                await protection.stopProtectingRoom(this.mjolnir, roomId);
+            } catch (ex) {
+                this.mjolnir.managementRoomOutput.logMessage(LogLevel.ERROR, protection.name, ex);
+            }
         }
     }
 }

--- a/test/integration/abuseReportTest.ts
+++ b/test/integration/abuseReportTest.ts
@@ -264,13 +264,6 @@ describe("Test: Reporting abuse", async () => {
         console.log("Test: Reporting abuse - send reports");
 
         // Time to report.
-        let reportToFind = {
-            reporterId: goodUserId,
-            accusedId: badUserId,
-            eventId: badEventId,
-            text: badText,
-            comment: null,
-        };
         try {
             await goodUser.doRequest("POST", `/_matrix/client/r0/rooms/${encodeURIComponent(roomId)}/report/${encodeURIComponent(badEventId)}`);
         } catch (e) {

--- a/test/integration/moderationRequestTest.ts
+++ b/test/integration/moderationRequestTest.ts
@@ -1,0 +1,335 @@
+import { strict as assert } from "assert";
+import { ABUSE_REPORT_KEY } from "../../src/report/ReportManager";
+import { newTestUser } from "./clientHelper";
+
+const REPORT_NOTICE_REGEXPS = {
+    reporter: /Filed by (?<reporterDisplay>[^ ]*) \((?<reporterId>[^ ]*)\)/,
+    accused: /Against (?<accusedDisplay>[^ ]*) \((?<accusedId>[^ ]*)\)/,
+    room: /Room (?<roomAliasOrId>[^ ]*)/,
+    event: /Event (?<eventId>[^ ]*) Go to event/,
+    content: /Content (?<eventContent>.*)/,
+    comments: /Comments Comments (?<comments>.*)/,
+    nature: /Nature (?<natureDisplay>[^(]*) \((?<natureSource>[^ ]*)\)/,
+};
+
+const EVENT_MODERATED_BY = "org.matrix.msc3215.room.moderation.moderated_by";
+const EVENT_MODERATOR_OF = "org.matrix.msc3215.room.moderation.moderator_of";
+const EVENT_MODERATION_REQUEST = "org.matrix.msc3215.abuse.report";
+
+describe("Test: Requesting moderation", async () => {
+    it(`Mjölnir propagates moderation requests`, async function() {
+        this.timeout(90000);
+
+        // Listen for any notices that show up.
+        let notices: any[] = [];
+
+        this.mjolnir.client.on("room.event", (roomId, event) => {
+            if (roomId = this.mjolnir.managementRoomId) {
+                notices.push(event);
+            }
+        });
+
+        // Create a few users and a room, make sure that Mjölnir is moderator in the room.
+        let goodUser = await newTestUser(this.config.homeserverUrl, { name: { contains: "reporting-abuse-good-user" }});
+        let badUser = await newTestUser(this.config.homeserverUrl, { name: { contains: "reporting-abuse-bad-user" }});
+        let goodUserId = await goodUser.getUserId();
+        let badUserId = await badUser.getUserId();
+
+        let roomId = await goodUser.createRoom({ invite: [await badUser.getUserId(), await this.mjolnir.client.getUserId()] });
+        await goodUser.inviteUser(await badUser.getUserId(), roomId);
+        await badUser.joinRoom(roomId);
+        await goodUser.setUserPowerLevel(await this.mjolnir.client.getUserId(), roomId, 100);
+
+        // Setup moderated_by/moderator_of.
+        await this.mjolnir.client.sendText(this.mjolnir.managementRoomId, `!mjolnir rooms setup ${roomId} reporting`);
+
+        // Prepare DM room to send moderation requests.
+        let dmRoomId = await goodUser.createRoom({ invite: [await this.mjolnir.client.getUserId() ]});
+        this.mjolnir.client.joinRoom(dmRoomId);
+
+        // Wait until moderated_by/moderator_of are setup
+        while (true) {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            try {
+                await goodUser.getRoomStateEvent(roomId, EVENT_MODERATED_BY, EVENT_MODERATED_BY);
+            } catch (ex) {
+                console.log("moderated_by not setup yet, waiting");
+                continue;
+            }
+            try {
+                await this.mjolnir.client.getRoomStateEvent(this.mjolnir.managementRoomId, EVENT_MODERATOR_OF, roomId);
+            } catch (ex) {
+                console.log("moderator_of not setup yet, waiting");
+                continue;
+            }
+            break;
+        }
+
+        console.log("Test: Requesting moderation - send messages");
+        // Exchange a few messages.
+        let goodText = `GOOD: ${Math.random()}`; // Will NOT be reported.
+        let badText = `BAD: ${Math.random()}`;   // Will be reported as abuse.
+        let badText2 = `BAD: ${Math.random()}`;   // Will be reported as abuse.
+        let badText3 = `<b>BAD</b>: ${Math.random()}`; // Will be reported as abuse.
+        let badText4 = [...Array(1024)].map(_ => `${Math.random()}`).join(""); // Text is too long.
+        let badText5 = [...Array(1024)].map(_ => "ABC").join("\n"); // Text has too many lines.
+        let badEventId = await badUser.sendText(roomId, badText);
+        let badEventId2 = await badUser.sendText(roomId, badText2);
+        let badEventId3 = await badUser.sendText(roomId, badText3);
+        let badEventId4 = await badUser.sendText(roomId, badText4);
+        let badEventId5 = await badUser.sendText(roomId, badText5);
+        let badEvent2Comment = `COMMENT: ${Math.random()}`;
+
+        console.log("Test: Requesting moderation - send reports");
+        let reportsToFind: any[] = []
+
+        let sendReport = async ({eventId, nature, comment, text, textPrefix}: {eventId: string, nature: string, text?: string, textPrefix?: string, comment?: string}) => {
+            await goodUser.sendRawEvent(dmRoomId, EVENT_MODERATION_REQUEST, {
+                event_id: eventId,
+                room_id: roomId,
+                moderated_by_id: await this.mjolnir.client.getUserId(),
+                nature,
+                reporter: goodUserId,
+                comment,
+            });
+            reportsToFind.push({
+                reporterId: goodUserId,
+                accusedId: badUserId,
+                eventId,
+                text,
+                textPrefix,
+                comment: comment || null,
+                nature,
+            });
+        };
+
+        // Without a comment.
+        await sendReport({ eventId: badEventId, nature: "org.matrix.msc3215.abuse.nature.disagreement", text: badText });
+        // With a comment.
+        await sendReport({ eventId: badEventId2, nature: "org.matrix.msc3215.abuse.nature.toxic", text: badText2, comment: badEvent2Comment });
+        // With html in the text.
+        await sendReport({ eventId: badEventId3, nature: "org.matrix.msc3215.abuse.nature.illegal", text: badText3 });
+        // With a long text.
+        await sendReport({ eventId: badEventId4, nature: "org.matrix.msc3215.abuse.nature.spam", textPrefix: badText4.substring(0, 256) });
+        // With a very long text.
+        await sendReport({ eventId: badEventId5, nature: "org.matrix.msc3215.abuse.nature.other", textPrefix: badText5.substring(0, 256).split("\n").join(" ") });
+
+        console.log("Test: Reporting abuse - wait");
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        let found: any[] = [];
+        for (let toFind of reportsToFind) {
+            for (let event of notices) {
+                if ("content" in event && "body" in event.content) {
+                    if (!(ABUSE_REPORT_KEY in event.content) || event.content[ABUSE_REPORT_KEY].event_id != toFind.eventId) {
+                        // Not a report or not our report.
+                        continue;
+                    }
+                    let report = event.content[ABUSE_REPORT_KEY];
+                    let body = event.content.body as string;
+                    let matches: Map<string, RegExpMatchArray> | null = new Map();
+                    for (let key of Object.keys(REPORT_NOTICE_REGEXPS)) {
+                        let match = body.match(REPORT_NOTICE_REGEXPS[key]);
+                        if (match) {
+                            console.debug("We have a match", key, REPORT_NOTICE_REGEXPS[key], match.groups);
+                        } else {
+                            console.debug("Not a match", key, REPORT_NOTICE_REGEXPS[key]);
+                            matches = null;
+                            break;
+                        }
+                        matches.set(key, match);
+                    }
+                    if (!matches) {
+                        // Not a report, skipping.
+                        console.debug("Not a report, skipping");
+                        continue;
+                    }
+
+                    assert(body.length < 3000, `The report shouldn't be too long ${body.length}`);
+                    assert(body.split("\n").length < 200, "The report shouldn't have too many newlines.");
+
+                    assert.equal(matches.get("event")!.groups!.eventId, toFind.eventId, "The report should specify the correct event id");;
+
+                    assert.equal(matches.get("reporter")!.groups!.reporterId, toFind.reporterId, "The report should specify the correct reporter");
+                    assert.equal(report.reporter_id, toFind.reporterId, "The embedded report should specify the correct reporter");
+                    assert.ok(toFind.reporterId.includes(matches.get("reporter")!.groups!.reporterDisplay), "The report should display the correct reporter");
+
+                    assert.equal(matches.get("accused")!.groups!.accusedId, toFind.accusedId, "The report should specify the correct accused");
+                    assert.equal(report.accused_id, toFind.accusedId, "The embedded report should specify the correct accused");
+                    assert.ok(toFind.accusedId.includes(matches.get("accused")!.groups!.accusedDisplay), "The report should display the correct reporter");
+
+                    if (toFind.text) {
+                        assert.equal(matches.get("content")!.groups!.eventContent, toFind.text, "The report should contain the text we inserted in the event");
+                    }
+                    if (toFind.textPrefix) {
+                        assert.ok(matches.get("content")!.groups!.eventContent.startsWith(toFind.textPrefix), `The report should contain a prefix of the long text we inserted in the event: ${toFind.textPrefix} in? ${matches.get("content")!.groups!.eventContent}`);
+                    }
+                    if (toFind.comment) {
+                        assert.equal(matches.get("comments")!.groups!.comments, toFind.comment, "The report should contain the comment we added");
+                    }
+                    assert.equal(matches.get("room")!.groups!.roomAliasOrId, roomId, "The report should specify the correct room");
+                    assert.equal(report.room_id, roomId, "The embedded report should specify the correct room");
+                    assert.equal(matches.get("nature")!.groups!.natureSource, toFind.nature, "The report should specify the correct nature");
+                    found.push(toFind);
+                    break;
+                }
+            }
+        }
+        assert.deepEqual(found, reportsToFind, `Found ${found.length} reports out of ${reportsToFind.length}`);
+    });
+
+    it('The redact action works', async function() {
+        this.timeout(60000);
+
+        // Listen for any notices that show up.
+        let notices: any[] = [];
+        this.mjolnir.client.on("room.event", (roomId, event) => {
+            if (roomId = this.mjolnir.managementRoomId) {
+                notices.push(event);
+            }
+        });
+
+        // Create a moderator.
+        let moderatorUser = await newTestUser(this.config.homeserverUrl, { name: { contains: "reporting-abuse-moderator-user" }});
+        this.mjolnir.client.inviteUser(await moderatorUser.getUserId(), this.mjolnir.managementRoomId);
+        await moderatorUser.joinRoom(this.mjolnir.managementRoomId);
+
+        // Create a few users and a room.
+        let goodUser = await newTestUser(this.config.homeserverUrl, { name: { contains: "reacting-abuse-good-user" }});
+        let badUser = await newTestUser(this.config.homeserverUrl, { name: { contains: "reacting-abuse-bad-user" }});
+        let goodUserId = await goodUser.getUserId();
+        let badUserId = await badUser.getUserId();
+
+        let roomId = await moderatorUser.createRoom({ invite: [await badUser.getUserId()] });
+        await moderatorUser.inviteUser(await goodUser.getUserId(), roomId);
+        await moderatorUser.inviteUser(await badUser.getUserId(), roomId);
+        await badUser.joinRoom(roomId);
+        await goodUser.joinRoom(roomId);
+
+        // Setup Mjölnir as moderator for our room.
+        await moderatorUser.inviteUser(await this.mjolnir.client.getUserId(), roomId);
+        await moderatorUser.setUserPowerLevel(await this.mjolnir.client.getUserId(), roomId, 100);
+
+        // Setup moderated_by/moderator_of.
+        await this.mjolnir.client.sendText(this.mjolnir.managementRoomId, `!mjolnir rooms setup ${roomId} reporting`);
+
+        // Prepare DM room to send moderation requests.
+        let dmRoomId = await goodUser.createRoom({ invite: [await this.mjolnir.client.getUserId() ]});
+        this.mjolnir.client.joinRoom(dmRoomId);
+
+        // Wait until moderated_by/moderator_of are setup
+        while (true) {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            try {
+                await goodUser.getRoomStateEvent(roomId, EVENT_MODERATED_BY, EVENT_MODERATED_BY);
+            } catch (ex) {
+                console.log("moderated_by not setup yet, waiting");
+                continue;
+            }
+            try {
+                await this.mjolnir.client.getRoomStateEvent(this.mjolnir.managementRoomId, EVENT_MODERATOR_OF, roomId);
+            } catch (ex) {
+                console.log("moderator_of not setup yet, waiting");
+                continue;
+            }
+            break;
+        }
+
+        console.log("Test: Reporting abuse - send messages");
+        // Exchange a few messages.
+        let goodText = `GOOD: ${Math.random()}`; // Will NOT be reported.
+        let badText = `BAD: ${Math.random()}`;   // Will be reported as abuse.
+        let goodEventId = await goodUser.sendText(roomId, goodText);
+        let badEventId = await badUser.sendText(roomId, badText);
+        let goodEventId2 = await goodUser.sendText(roomId, goodText);
+
+        console.log("Test: Reporting abuse - send reports");
+
+        // Time to report.
+        await goodUser.sendRawEvent(dmRoomId, EVENT_MODERATION_REQUEST, {
+            event_id: badEventId,
+            room_id: roomId,
+            moderated_by_id: await this.mjolnir.client.getUserId(),
+            nature: "org.matrix.msc3215.abuse.nature.test",
+            reporter: goodUserId,
+        });
+
+
+        console.log("Test: Reporting abuse - wait");
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        let mjolnirRooms = new Set(await this.mjolnir.client.getJoinedRooms());
+        assert.ok(mjolnirRooms.has(roomId), "Mjölnir should be a member of the room");
+
+        // Find the notice
+        let noticeId;
+        for (let event of notices) {
+            if ("content" in event && ABUSE_REPORT_KEY in event.content) {
+                if (!(ABUSE_REPORT_KEY in event.content) || event.content[ABUSE_REPORT_KEY].event_id != badEventId) {
+                    // Not a report or not our report.
+                    continue;
+                }
+                noticeId = event.event_id;
+                break;
+            }
+        }
+        assert.ok(noticeId, "We should have found our notice");
+
+        // Find the buttons.
+        let buttons: any[] = [];
+        for (let event of notices) {
+            if (event["type"] != "m.reaction") {
+                continue;
+            }
+            if (event["content"]["m.relates_to"]["rel_type"] != "m.annotation") {
+                continue;
+            }
+            if (event["content"]["m.relates_to"]["event_id"] != noticeId) {
+                continue;
+            }
+            buttons.push(event);
+        }
+
+        // Find the redact button... and click it.
+        let redactButtonId = null;
+        for (let button of buttons) {
+            if (button["content"]["m.relates_to"]["key"].includes("[redact-message]")) {
+                redactButtonId = button["event_id"];
+                await moderatorUser.sendEvent(this.mjolnir.managementRoomId, "m.reaction", button["content"]);
+                break;
+            }
+        }
+        assert.ok(redactButtonId, "We should have found the redact button");
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        // This should have triggered a confirmation request, with more buttons!
+        let confirmEventId = null;
+        for (let event of notices) {
+            console.debug("Is this the confirm button?", event);
+            if (!event["content"]["m.relates_to"]) {
+                console.debug("Not a reaction");
+                continue;
+            }
+            if (!event["content"]["m.relates_to"]["key"].includes("[confirm]")) {
+                console.debug("Not confirm");
+                continue;
+            }
+            if (!event["content"]["m.relates_to"]["event_id"] == redactButtonId) {
+                console.debug("Not reaction to redact button");
+                continue;
+            }
+
+            // It's the confirm button, click it!
+            confirmEventId = event["event_id"];
+            await moderatorUser.sendEvent(this.mjolnir.managementRoomId, "m.reaction", event["content"]);
+            break;
+        }
+        assert.ok(confirmEventId, "We should have found the confirm button");
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        // This should have redacted the message.
+        let newBadEvent = await this.mjolnir.client.getEvent(roomId, badEventId);
+        assert.deepEqual(Object.keys(newBadEvent.content), [], "Redaction should have removed the content of the offending event");
+    });
+});

--- a/test/integration/protectionSettingsTest.ts
+++ b/test/integration/protectionSettingsTest.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from "assert";
 
 import { Mjolnir } from "../../src/Mjolnir";
-import { IProtection } from "../../src/protections/IProtection";
+import { Protection } from "../../src/protections/IProtection";
 import { ProtectionSettingValidationError } from "../../src/protections/ProtectionSettings";
 import { NumberProtectionSetting, StringProtectionSetting, StringListProtectionSetting } from "../../src/protections/ProtectionSettings";
 import { newTestUser, noticeListener } from "./clientHelper";
@@ -26,7 +26,7 @@ describe("Test: Protection settings", function() {
     it("Mjolnir successfully saves valid protection setting values", async function() {
         this.timeout(20000);
 
-        await this.mjolnir.protectionManager.registerProtection(new class implements IProtection {
+        await this.mjolnir.protectionManager.registerProtection(new class extends Protection {
             name = "05OVMS";
             description = "A test protection";
             settings = { test: new NumberProtectionSetting(3) };
@@ -41,8 +41,9 @@ describe("Test: Protection settings", function() {
     it("Mjolnir should accumulate changed settings", async function() {
         this.timeout(20000);
 
-        await this.mjolnir.protectionManager.registerProtection(new class implements IProtection {
+        await this.mjolnir.protectionManager.registerProtection(new class extends Protection {
             name = "HPUjKN";
+            description = "A test protection";
             settings = {
                 test1: new NumberProtectionSetting(3),
                 test2: new NumberProtectionSetting(4)
@@ -59,7 +60,7 @@ describe("Test: Protection settings", function() {
         this.timeout(20000);
         await client.joinRoom(this.config.managementRoom);
 
-        await this.mjolnir.protectionManager.registerProtection(new class implements IProtection {
+        await this.mjolnir.protectionManager.registerProtection(new class extends Protection {
             name = "JY2TPN";
             description = "A test protection";
             settings = { test: new StringProtectionSetting() };
@@ -84,7 +85,7 @@ describe("Test: Protection settings", function() {
         this.timeout(20000);
         await client.joinRoom(this.config.managementRoom);
 
-        await this.mjolnir.protectionManager.registerProtection(new class implements IProtection {
+        await this.mjolnir.protectionManager.registerProtection(new class extends Protection {
             name = "r33XyT";
             description = "A test protection";
             settings = { test: new StringListProtectionSetting() };
@@ -108,7 +109,7 @@ describe("Test: Protection settings", function() {
         this.timeout(20000);
         await client.joinRoom(this.config.managementRoom);
 
-        await this.mjolnir.protectionManager.registerProtection(new class implements IProtection {
+        await this.mjolnir.protectionManager.registerProtection(new class extends Protection {
             name = "oXzT0E";
             description = "A test protection";
             settings = { test: new StringListProtectionSetting() };
@@ -133,13 +134,13 @@ describe("Test: Protection settings", function() {
         this.timeout(20000);
         await client.joinRoom(this.config.managementRoom);
 
-        await this.mjolnir.protectionManager.registerProtection(new class implements IProtection {
+        await this.mjolnir.protectionManager.registerProtection(new class extends Protection {
             name = "d0sNrt";
             description = "A test protection";
             settings = { test: new StringProtectionSetting() };
         });
 
-        let replyPromise = new Promise((resolve, reject) => {
+        let replyPromise: Promise<any> = new Promise((resolve, reject) => {
             let i = 0;
             client.on('room.message', noticeListener(this.mjolnir.managementRoomId, (event) => {
                 if (event.content.body.includes("Changed d0sNrt.test ")) {

--- a/test/integration/reportPollingTest.ts
+++ b/test/integration/reportPollingTest.ts
@@ -1,5 +1,5 @@
 import { Mjolnir } from "../../src/Mjolnir";
-import { IProtection } from "../../src/protections/IProtection";
+import { Protection } from "../../src/protections/IProtection";
 import { newTestUser } from "./clientHelper";
 
 describe("Test: Report polling", function() {
@@ -15,18 +15,21 @@ describe("Test: Report polling", function() {
         await this.mjolnir.addProtectedRoom(protectedRoomId);
 
         const eventId = await client.sendMessage(protectedRoomId, {msgtype: "m.text", body: "uwNd3q"});
+        class CustomProtection extends Protection {
+            name = "jYvufI";
+            description = "A test protection";
+            settings = { };
+            constructor(private resolve) {
+                super();
+            }
+            async handleReport (mjolnir: Mjolnir, roomId: string, reporterId: string, event: any, reason?: string) {
+                if (reason === "x5h1Je") {
+                    this.resolve(null);
+                }
+            }
+        }
         await new Promise(async resolve => {
-            await this.mjolnir.protectionManager.registerProtection(new class implements IProtection {
-                name = "jYvufI";
-                description = "A test protection";
-                settings = { };
-                handleEvent = async (mjolnir: Mjolnir, roomId: string, event: any) => { };
-                handleReport = (mjolnir: Mjolnir, roomId: string, reporterId: string, event: any, reason?: string) => {
-                    if (reason === "x5h1Je") {
-                        resolve(null);
-                    }
-                };
-            });
+            await this.mjolnir.protectionManager.registerProtection(new CustomProtection(resolve));
             await this.mjolnir.protectionManager.enableProtection("jYvufI");
             await client.doRequest(
                 "POST",

--- a/test/integration/standardConsequenceTest.ts
+++ b/test/integration/standardConsequenceTest.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from "assert";
 
 import { Mjolnir } from "../../src/Mjolnir";
-import { IProtection } from "../../src/protections/IProtection";
+import { Protection } from "../../src/protections/IProtection";
 import { newTestUser, noticeListener } from "./clientHelper";
 import { matrixClient, mjolnir } from "./mjolnirSetupUtils";
 import { ConsequenceBan, ConsequenceRedact } from "../../src/protections/consequence";
@@ -27,7 +27,7 @@ describe("Test: standard consequences", function() {
         await badUser.joinRoom(protectedRoomId);
         await this.mjolnir.addProtectedRoom(protectedRoomId);
 
-        await this.mjolnir.protectionManager.registerProtection(new class implements IProtection {
+        await this.mjolnir.protectionManager.registerProtection(new class extends Protection {
             name = "JY2TPN";
             description = "A test protection";
             settings = { };
@@ -39,7 +39,7 @@ describe("Test: standard consequences", function() {
         });
         await this.mjolnir.protectionManager.enableProtection("JY2TPN");
 
-        let reply = new Promise(async (resolve, reject) => {
+        let reply: Promise<any> = new Promise(async (resolve, reject) => {
             const messageId = await badUser.sendMessage(protectedRoomId, {msgtype: "m.text", body: "ngmWkF"});
             let redaction;
             badUser.on('room.event', (roomId, event) => {
@@ -71,7 +71,7 @@ describe("Test: standard consequences", function() {
         await badUser.joinRoom(protectedRoomId);
         await this.mjolnir.addProtectedRoom(protectedRoomId);
 
-        await this.mjolnir.protectionManager.registerProtection(new class implements IProtection {
+        await this.mjolnir.protectionManager.registerProtection(new class extends Protection {
             name = "0LxMTy";
             description = "A test protection";
             settings = { };
@@ -83,7 +83,7 @@ describe("Test: standard consequences", function() {
         });
         await this.mjolnir.protectionManager.enableProtection("0LxMTy");
 
-        let reply = new Promise(async (resolve, reject) => {
+        let reply: Promise<any> = new Promise(async (resolve, reject) => {
             const messageId = await badUser.sendMessage(protectedRoomId, {msgtype: "m.text", body: "7Uga3d"});
             let ban;
             badUser.on('room.leave', (roomId, event) => {
@@ -118,7 +118,7 @@ describe("Test: standard consequences", function() {
         await goodUser.joinRoom(protectedRoomId);
         await this.mjolnir.addProtectedRoom(protectedRoomId);
 
-        await this.mjolnir.protectionManager.registerProtection(new class implements IProtection {
+        await this.mjolnir.protectionManager.registerProtection(new class extends Protection {
             name = "95B1Cr";
             description = "A test protection";
             settings = { };


### PR DESCRIPTION
Traditionally, when a user clicks "report" in a Matrix client, this goes to the homeserver administrator, who often is the wrong person for the job.

MSC3215 introduces a mechanism to let clients cooperate with a bot to send the report to the moderator instead. Client support has landed in Element Web (behind a Labs flag) in in 2021. This allows Mjölnir to serve as the partner bot.