### PR TITLE
Detect stickers as media

### DIFF
--- a/src/protections/MessageIsMedia.ts
+++ b/src/protections/MessageIsMedia.ts
@@ -38,7 +38,7 @@ export class MessageIsMedia extends Protection {
             const content = event['content'] || {};
             const msgtype = content['msgtype'] || 'm.text';
             const formattedBody = content['formatted_body'] || '';
-            const isMedia = msgtype === 'm.image' || msgtype === 'm.video' || formattedBody.toLowerCase().includes('<img');
+            const isMedia = msgtype === 'm.image' || msgtype === 'm.video' || msgtype === 'm.sticker' || formattedBody.toLowerCase().includes('<img');
             if (isMedia) {
                 await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MessageIsMedia", `Redacting event from ${event['sender']} for posting an image/video. ${Permalinks.forEvent(roomId, event['event_id'], [new UserID(await mjolnir.client.getUserId()).domain])}`);
                 // Redact the event


### PR DESCRIPTION
Currently, you can circumvent blocks on media using stickers. Since sticker messages basically allow you to embed an arbitrary image, they have almost equivalent functionality to images, and should count as media to be blocked as well.

Credit to @eyjhb for successfully hacking together a custom event showing cat pictures to demonstrate. 