### PR TITLE
Check for via servers before trying to join room in policy list manager

### DIFF
--- a/src/models/PolicyList.ts
+++ b/src/models/PolicyList.ts
@@ -663,8 +663,7 @@ export class PolicyListManager {
         if (permalink.roomIdOrAlias.startsWith("!")) {
             roomId = permalink.roomIdOrAlias
             viaServers = permalink.viaServers
-        }
-        else {
+        } else {
             const roomInfo = await this.mjolnir.client.lookupRoomAlias(permalink.roomIdOrAlias)
             roomId = roomInfo.roomId
             viaServers = roomInfo.residentServers

--- a/src/models/PolicyList.ts
+++ b/src/models/PolicyList.ts
@@ -658,9 +658,20 @@ export class PolicyListManager {
         const permalink = Permalinks.parseUrl(roomRef);
         if (!permalink.roomIdOrAlias) return null;
 
-        const roomId = await this.mjolnir.client.resolveRoom(permalink.roomIdOrAlias);
+        let roomId: string;
+        let viaServers;
+        if (permalink.roomIdOrAlias.startsWith("!")) {
+            roomId = permalink.roomIdOrAlias
+            viaServers = permalink.viaServers
+        }
+        else {
+            const roomInfo = await this.mjolnir.client.lookupRoomAlias(permalink.roomIdOrAlias)
+            roomId = roomInfo.roomId
+            viaServers = roomInfo.residentServers
+        }
+
         if (!joinedRooms.includes(roomId)) {
-            await this.mjolnir.client.joinRoom(roomId, permalink.viaServers);
+            await this.mjolnir.client.joinRoom(roomId, viaServers);
         }
 
         if (this.policyLists.find(b => b.roomId === roomId)) {


### PR DESCRIPTION
In some cases the matrix.to url provided to the policy list is just a room alias that's been converted to the matrix.to url format. If that's the case, make sure we resolve the alias in a way that captures the via servers before trying to join the room. 

Fixes #503