### PR TITLE
remove real name requirement from DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,11 +160,6 @@ include the line in your commit or pull request comment:
 Signed-off-by: Your Name <your@email.example.org>
 ```
 
-We accept contributions under a legally identifiable name, such as
-your name on government documentation or common-law names (names
-claimed by legitimate usage or repute). Unfortunately, we cannot
-accept anonymous contributions at this time.
-
 Git allows you to add this signoff automatically when using the `-s`
 flag to `git commit`, which uses the name and email set in your
 `user.name` and `user.email` git configs.


### PR DESCRIPTION
The Matrix.org Foundation is rolling out this updated DCO across all public repositories in its namespace. Of note, this DCO does not require the use of "real" or "legally identifiable" names.