### PR TITLE
Resolve aliases and get via servers before storing watch list

### DIFF
--- a/src/models/PolicyList.ts
+++ b/src/models/PolicyList.ts
@@ -661,11 +661,17 @@ export class PolicyListManager {
         let roomId: string;
         let viaServers: string[];
         if (permalink.roomIdOrAlias.startsWith("!")) {
-            // get alias and then use alias to get via servers
+            // if we only have a room id, see if there's an alias we can use to get any possible
+            // via servers
             const alias = await this.mjolnir.client.getPublishedAlias(permalink.roomIdOrAlias)
-            const roomInformation = await this.mjolnir.client.lookupRoomAlias(alias)
-            roomId = permalink.roomIdOrAlias
-            viaServers = roomInformation.residentServers
+            if (alias) {
+                const roomInformation = await this.mjolnir.client.lookupRoomAlias(alias)
+                roomId = permalink.roomIdOrAlias
+                viaServers = roomInformation.residentServers
+            } else {
+                roomId = permalink.roomIdOrAlias
+                viaServers = permalink.viaServers
+            }
         } else {
             const roomInfo = await this.mjolnir.client.lookupRoomAlias(permalink.roomIdOrAlias)
             roomId = roomInfo.roomId

--- a/src/models/PolicyList.ts
+++ b/src/models/PolicyList.ts
@@ -659,10 +659,13 @@ export class PolicyListManager {
         if (!permalink.roomIdOrAlias) return null;
 
         let roomId: string;
-        let viaServers;
+        let viaServers: string[];
         if (permalink.roomIdOrAlias.startsWith("!")) {
+            // get alias and then use alias to get via servers
+            const alias = await this.mjolnir.client.getPublishedAlias(permalink.roomIdOrAlias)
+            const roomInformation = await this.mjolnir.client.lookupRoomAlias(alias)
             roomId = permalink.roomIdOrAlias
-            viaServers = permalink.viaServers
+            viaServers = roomInformation.residentServers
         } else {
             const roomInfo = await this.mjolnir.client.lookupRoomAlias(permalink.roomIdOrAlias)
             roomId = roomInfo.roomId
@@ -682,7 +685,8 @@ export class PolicyListManager {
             return null;
         }
 
-        const list = await this.addPolicyList(roomId, roomRef);
+        const newRef = Permalinks.forRoom(roomId, viaServers)
+        const list = await this.addPolicyList(roomId, newRef);
 
         await this.storeWatchedPolicyLists();
 


### PR DESCRIPTION
Resolves #404. Resolves aliases and gets any via servers before storing in watch list (note that this builds on #514). 