### PR TITLE
Add protection for mention spam

### DIFF
--- a/src/protections/MentionSpam.ts
+++ b/src/protections/MentionSpam.ts
@@ -40,10 +40,8 @@ export class MentionSpam extends Protection {
 
     public checkMentions(body: unknown|undefined, htmlBody: unknown|undefined, mentionArray: unknown|undefined): boolean {
         const max = this.settings.maxMentions.value;
-        if (Array.isArray(mentionArray)) {
-            if (mentionArray.length > this.settings.maxMentions.value) {
-                return true;
-            }
+        if (Array.isArray(mentionArray) && mentionArray.length > max) {
+            return true;
         }
         if (typeof body === "string" && body.split('@').length - 1 > max) {
             return true;

--- a/src/protections/MentionSpam.ts
+++ b/src/protections/MentionSpam.ts
@@ -20,7 +20,6 @@ import { LogLevel, Permalinks, UserID } from "@vector-im/matrix-bot-sdk";
 import { NumberProtectionSetting } from "./ProtectionSettings";
 
 export const DEFAULT_MAX_MENTIONS = 10;
-const USER_ID_SIGIL_REGEX = /(@|%40)/;
 
 export class MentionSpam extends Protection {
 
@@ -41,31 +40,16 @@ export class MentionSpam extends Protection {
 
     public checkMentions(body: unknown|undefined, htmlBody: unknown|undefined, mentionArray: unknown|undefined): boolean {
         const max = this.settings.maxMentions.value;
-        const minMessageLength = max * 3; // "@:a"
         if (Array.isArray(mentionArray)) {
             if (mentionArray.length > this.settings.maxMentions.value) {
                 return true;
             }
         }
-        if (typeof body === "string" && body.length > minMessageLength) {
-            let found = 0;
-            for (const word of body.split(/\s/)) {
-                if (USER_ID_SIGIL_REGEX.test(word.trim())) {
-                    if (++found > max) {
-                        return true;
-                    }
-                }
-            }
+        if (typeof body === "string" && body.split('@').length - 1 > max) {
+            return true;
         }
-        if (typeof htmlBody === "string" && htmlBody.length > minMessageLength) {
-            let found = 0;
-            for (const word of htmlBody.split(/\s/)) {
-                if (USER_ID_SIGIL_REGEX.test(word.trim())) {
-                    if (++found > max) {
-                        return true;
-                    }
-                }
-            }
+        if (typeof htmlBody === "string" && htmlBody.split('%40').length - 1 > max) {
+            return true;
         }
         return false;
     }

--- a/src/protections/MentionSpam.ts
+++ b/src/protections/MentionSpam.ts
@@ -1,0 +1,88 @@
+/*
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Protection } from "./IProtection";
+import { Mjolnir } from "../Mjolnir";
+import { LogLevel, Permalinks, UserID } from "@vector-im/matrix-bot-sdk";
+import { NumberProtectionSetting } from "./ProtectionSettings";
+
+const MAX_MENTIONS = 8;
+const USER_ID_REGEX = /@[^:]*:.+/;
+
+export class MentionSpam extends Protection {
+
+    settings = {
+        maxMentions: new NumberProtectionSetting(MAX_MENTIONS),
+    };
+
+    constructor() {
+        super();
+    }
+
+    public get name(): string {
+        return 'MentionSpam';
+    }
+    public get description(): string {
+        return "If a user posts many mentions, that message is redacted. No bans are issued.";
+    }
+
+    public checkMentions(body: unknown|undefined, htmlBody: unknown|undefined, mentionArray: unknown|undefined): boolean {
+        const max = this.settings.maxMentions.value;
+        if (Array.isArray(mentionArray)) {
+            if (mentionArray.length > this.settings.maxMentions.value) {
+                return true;
+            }
+        }
+        if (typeof body === "string") {
+            let found = 0;
+            for (const word of body.split(/\s/)) {
+                if (USER_ID_REGEX.test(word.trim())) {
+                    if (found++ > max) {
+                        return true;
+                    }
+                }
+            }
+        }
+        if (typeof htmlBody === "string") {
+            let found = 0;
+            for (const word of htmlBody.split(/\s/)) {
+                if (USER_ID_REGEX.test(word.trim())) {
+                    if (found++ > max) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any> {
+        if (event['type'] === 'm.room.message') {
+            let content = event['content'] || {};
+            const explicitMentions = content["m.mentions"]?.["m.user_ids"];
+            const hitLimit = this.checkMentions(content.body, content.formatted_body, explicitMentions);
+            if (hitLimit) {
+                await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MessageIsMedia", `Redacting event from ${event['sender']} for spamming mentions. ${Permalinks.forEvent(roomId, event['event_id'], [new UserID(await mjolnir.client.getUserId()).domain])}`);
+                // Redact the event
+                if (!mjolnir.config.noop) {
+                    await mjolnir.client.redactEvent(roomId, event['event_id'], "Message was detected as spam.");
+                } else {
+                    await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MessageIsMedia", `Tried to redact ${event['event_id']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                }
+            }
+        }
+    }
+}

--- a/src/protections/MentionSpam.ts
+++ b/src/protections/MentionSpam.ts
@@ -25,7 +25,7 @@ const USER_ID_REGEX = /@[^:]*:.+/;
 export class MentionSpam extends Protection {
 
     settings = {
-        maxMentionsRedact: new NumberProtectionSetting(DEFAULT_MAX_MENTIONS),
+        maxMentions: new NumberProtectionSetting(DEFAULT_MAX_MENTIONS),
     };
 
     constructor() {

--- a/src/protections/MentionSpam.ts
+++ b/src/protections/MentionSpam.ts
@@ -19,13 +19,13 @@ import { Mjolnir } from "../Mjolnir";
 import { LogLevel, Permalinks, UserID } from "matrix-bot-sdk";
 import { NumberProtectionSetting } from "./ProtectionSettings";
 
-export const DEFAULT_MAX_MENTIONS = 8;
+export const DEFAULT_MAX_MENTIONS = 10;
 const USER_ID_REGEX = /@[^:]*:.+/;
 
 export class MentionSpam extends Protection {
 
     settings = {
-        maxMentions: new NumberProtectionSetting(DEFAULT_MAX_MENTIONS),
+        maxMentionsRedact: new NumberProtectionSetting(DEFAULT_MAX_MENTIONS),
     };
 
     constructor() {

--- a/src/protections/MentionSpam.ts
+++ b/src/protections/MentionSpam.ts
@@ -41,12 +41,13 @@ export class MentionSpam extends Protection {
 
     public checkMentions(body: unknown|undefined, htmlBody: unknown|undefined, mentionArray: unknown|undefined): boolean {
         const max = this.settings.maxMentions.value;
+        const minMessageLength = max * 3; // "@:a"
         if (Array.isArray(mentionArray)) {
             if (mentionArray.length > this.settings.maxMentions.value) {
                 return true;
             }
         }
-        if (typeof body === "string") {
+        if (typeof body === "string" && body.length > minMessageLength) {
             let found = 0;
             for (const word of body.split(/\s/)) {
                 if (USER_ID_SIGIL_REGEX.test(word.trim())) {
@@ -56,7 +57,7 @@ export class MentionSpam extends Protection {
                 }
             }
         }
-        if (typeof htmlBody === "string") {
+        if (typeof htmlBody === "string" && htmlBody.length > minMessageLength) {
             let found = 0;
             for (const word of htmlBody.split(/\s/)) {
                 if (USER_ID_SIGIL_REGEX.test(word.trim())) {

--- a/src/protections/MentionSpam.ts
+++ b/src/protections/MentionSpam.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { Protection } from "./IProtection";
 import { Mjolnir } from "../Mjolnir";
-import { LogLevel, Permalinks, UserID } from "@vector-im/matrix-bot-sdk";
+import { LogLevel, Permalinks, UserID } from "matrix-bot-sdk";
 import { NumberProtectionSetting } from "./ProtectionSettings";
 
 export const DEFAULT_MAX_MENTIONS = 8;

--- a/src/protections/MentionSpam.ts
+++ b/src/protections/MentionSpam.ts
@@ -72,7 +72,7 @@ export class MentionSpam extends Protection {
     public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any> {
         if (event['type'] === 'm.room.message') {
             let content = event['content'] || {};
-            const explicitMentions = content["m.mentions"]?.["m.user_ids"];
+            const explicitMentions = content["m.mentions"]?.user_ids;
             const hitLimit = this.checkMentions(content.body, content.formatted_body, explicitMentions);
             if (hitLimit) {
                 await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MentionSpam", `Redacting event from ${event['sender']} for spamming mentions. ${Permalinks.forEvent(roomId, event['event_id'], [new UserID(await mjolnir.client.getUserId()).domain])}`);

--- a/src/protections/MentionSpam.ts
+++ b/src/protections/MentionSpam.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { Protection } from "./IProtection";
 import { Mjolnir } from "../Mjolnir";
-import { LogLevel, Permalinks, UserID } from "matrix-bot-sdk";
+import { LogLevel, Permalinks, UserID } from "@vector-im/matrix-bot-sdk";
 import { NumberProtectionSetting } from "./ProtectionSettings";
 
 export const DEFAULT_MAX_MENTIONS = 10;

--- a/src/protections/MentionSpam.ts
+++ b/src/protections/MentionSpam.ts
@@ -50,7 +50,7 @@ export class MentionSpam extends Protection {
             let found = 0;
             for (const word of body.split(/\s/)) {
                 if (USER_ID_REGEX.test(word.trim())) {
-                    if (found++ > max) {
+                    if (++found > max) {
                         return true;
                     }
                 }
@@ -60,7 +60,7 @@ export class MentionSpam extends Protection {
             let found = 0;
             for (const word of htmlBody.split(/\s/)) {
                 if (USER_ID_REGEX.test(word.trim())) {
-                    if (found++ > max) {
+                    if (++found > max) {
                         return true;
                     }
                 }

--- a/src/protections/MentionSpam.ts
+++ b/src/protections/MentionSpam.ts
@@ -19,13 +19,13 @@ import { Mjolnir } from "../Mjolnir";
 import { LogLevel, Permalinks, UserID } from "@vector-im/matrix-bot-sdk";
 import { NumberProtectionSetting } from "./ProtectionSettings";
 
-const MAX_MENTIONS = 8;
+export const DEFAULT_MAX_MENTIONS = 8;
 const USER_ID_REGEX = /@[^:]*:.+/;
 
 export class MentionSpam extends Protection {
 
     settings = {
-        maxMentions: new NumberProtectionSetting(MAX_MENTIONS),
+        maxMentions: new NumberProtectionSetting(DEFAULT_MAX_MENTIONS),
     };
 
     constructor() {

--- a/src/protections/MentionSpam.ts
+++ b/src/protections/MentionSpam.ts
@@ -75,12 +75,12 @@ export class MentionSpam extends Protection {
             const explicitMentions = content["m.mentions"]?.["m.user_ids"];
             const hitLimit = this.checkMentions(content.body, content.formatted_body, explicitMentions);
             if (hitLimit) {
-                await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MessageIsMedia", `Redacting event from ${event['sender']} for spamming mentions. ${Permalinks.forEvent(roomId, event['event_id'], [new UserID(await mjolnir.client.getUserId()).domain])}`);
+                await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MentionSpam", `Redacting event from ${event['sender']} for spamming mentions. ${Permalinks.forEvent(roomId, event['event_id'], [new UserID(await mjolnir.client.getUserId()).domain])}`);
                 // Redact the event
                 if (!mjolnir.config.noop) {
                     await mjolnir.client.redactEvent(roomId, event['event_id'], "Message was detected as spam.");
                 } else {
-                    await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MessageIsMedia", `Tried to redact ${event['event_id']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
+                    await mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "MentionSpam", `Tried to redact ${event['event_id']} in ${roomId} but Mjolnir is running in no-op mode`, roomId);
                 }
             }
         }

--- a/src/protections/MentionSpam.ts
+++ b/src/protections/MentionSpam.ts
@@ -25,7 +25,7 @@ const USER_ID_REGEX = /@[^:]*:.+/;
 export class MentionSpam extends Protection {
 
     settings = {
-        maxMentions: new NumberProtectionSetting(DEFAULT_MAX_MENTIONS),
+        maxMentions: new NumberProtectionSetting(DEFAULT_MAX_MENTIONS, 1),
     };
 
     constructor() {

--- a/src/protections/MentionSpam.ts
+++ b/src/protections/MentionSpam.ts
@@ -20,7 +20,7 @@ import { LogLevel, Permalinks, UserID } from "@vector-im/matrix-bot-sdk";
 import { NumberProtectionSetting } from "./ProtectionSettings";
 
 export const DEFAULT_MAX_MENTIONS = 10;
-const USER_ID_REGEX = /@[^:]*:.+/;
+const USER_ID_SIGIL_REGEX = /(@|%40)/;
 
 export class MentionSpam extends Protection {
 
@@ -49,7 +49,7 @@ export class MentionSpam extends Protection {
         if (typeof body === "string") {
             let found = 0;
             for (const word of body.split(/\s/)) {
-                if (USER_ID_REGEX.test(word.trim())) {
+                if (USER_ID_SIGIL_REGEX.test(word.trim())) {
                     if (++found > max) {
                         return true;
                     }
@@ -59,7 +59,7 @@ export class MentionSpam extends Protection {
         if (typeof htmlBody === "string") {
             let found = 0;
             for (const word of htmlBody.split(/\s/)) {
-                if (USER_ID_REGEX.test(word.trim())) {
+                if (USER_ID_SIGIL_REGEX.test(word.trim())) {
                     if (++found > max) {
                         return true;
                     }

--- a/src/protections/ProtectionManager.ts
+++ b/src/protections/ProtectionManager.ts
@@ -24,7 +24,7 @@ import { MessageIsMedia } from "./MessageIsMedia";
 import { TrustedReporters } from "./TrustedReporters";
 import { JoinWaveShortCircuit } from "./JoinWaveShortCircuit";
 import { Mjolnir } from "../Mjolnir";
-import { extractRequestError, LogLevel, LogService, Permalinks } from "@vector-im/matrix-bot-sdk";
+import { extractRequestError, LogLevel, LogService, Permalinks } from "matrix-bot-sdk";
 import { ProtectionSettingValidationError } from "./ProtectionSettings";
 import { Consequence } from "./consequence";
 import { htmlEscape } from "../utils";

--- a/src/protections/ProtectionManager.ts
+++ b/src/protections/ProtectionManager.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 - 2022 The Matrix.org Foundation C.I.C.
+Copyright 2019 - 2024 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import { MessageIsMedia } from "./MessageIsMedia";
 import { TrustedReporters } from "./TrustedReporters";
 import { JoinWaveShortCircuit } from "./JoinWaveShortCircuit";
 import { Mjolnir } from "../Mjolnir";
-import { extractRequestError, LogLevel, LogService, Permalinks } from "matrix-bot-sdk";
+import { extractRequestError, LogLevel, LogService, Permalinks } from "@vector-im/matrix-bot-sdk";
 import { ProtectionSettingValidationError } from "./ProtectionSettings";
 import { Consequence } from "./consequence";
 import { htmlEscape } from "../utils";
@@ -32,6 +32,7 @@ import { ERROR_KIND_FATAL, ERROR_KIND_PERMISSION } from "../ErrorCache";
 import { RoomUpdateError } from "../models/RoomUpdateError";
 import { LocalAbuseReports } from "./LocalAbuseReports";
 import {NsfwProtection} from "./NsfwProtection";
+import { MentionSpam } from "./MentionSpam";
 
 const PROTECTIONS: Protection[] = [
     new FirstMessageIsImage(),
@@ -43,7 +44,8 @@ const PROTECTIONS: Protection[] = [
     new DetectFederationLag(),
     new JoinWaveShortCircuit(),
     new LocalAbuseReports(),
-    new NsfwProtection()
+    new NsfwProtection(),
+    new MentionSpam()
 ];
 
 const ENABLED_PROTECTIONS_EVENT_TYPE = "org.matrix.mjolnir.enabled_protections";

--- a/test/integration/mentionSpamProtectionTest.ts
+++ b/test/integration/mentionSpamProtectionTest.ts
@@ -1,0 +1,93 @@
+import {newTestUser} from "./clientHelper";
+
+import {MatrixClient} from "matrix-bot-sdk";
+import {getFirstReaction} from "./commands/commandUtils";
+import {strict as assert} from "assert";
+import { DEFAULT_MAX_MENTIONS } from "../../src/protections/MentionSpam";
+
+describe("Test: Mention spam protection", function () {
+    let client: MatrixClient;
+    let room: string;
+    this.beforeEach(async function () {
+        client = await newTestUser(this.config.homeserverUrl, {name: {contains: "mention-spam-protection"}});
+        await client.start();
+        const mjolnirId = await this.mjolnir.client.getUserId();
+        room = await client.createRoom({ invite: [mjolnirId] });
+        await client.joinRoom(room);
+        await client.joinRoom(this.config.managementRoom);
+        await client.setUserPowerLevel(mjolnirId, room, 100);
+    })
+    this.afterEach(async function () {
+        await client.stop();
+    })
+
+    function delay(ms: number) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+
+    it("does not redact a normal message", async function() {
+        await client.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir rooms add ${room}` });
+        await getFirstReaction(client, this.mjolnir.managementRoomId, '✅', async () => {
+                return await client.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: "!mjolnir enable MentionSpam" });
+        });
+        const testMessage = await client.sendText(room, 'Hello world');
+
+        await delay(500);
+        const fetchedEvent = await client.getEvent(room, testMessage);
+        assert.equal(Object.keys(fetchedEvent.content).length, 3, "This event should not have been redacted");
+    });
+
+    it("does not redact a message with some mentions", async function() {
+        await client.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir rooms add ${room}` });
+        await getFirstReaction(client, this.mjolnir.managementRoomId, '✅', async () => {
+                return await client.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: "!mjolnir enable MentionSpam" });
+        });
+        // Also covers HTML mentions
+        const messageWithTextMentions = await client.sendText(room, 'Hello world @foo:bar @beep:boop @test:here');
+        const messageWithMMentions = await client.sendMessage(room, {
+            content: {
+                msgtype: 'm.text',
+                body: 'Hello world',
+                ['m.mentions']: {
+                    user_ids: [
+                        "@foo:bar",
+                        "@beep:boop",
+                        "@test:here"
+                    ]
+                }
+            }
+        });
+
+        await delay(500);
+        const fetchedTextEvent = await client.getEvent(room, messageWithTextMentions);
+        assert.equal(Object.keys(fetchedTextEvent.content).length, 3, "This event should not have been redacted");
+        const fetchedMentionsEvent = await client.getEvent(room, messageWithMMentions);
+        assert.equal(Object.keys(fetchedMentionsEvent.content).length, 3, "This event should not have been redacted");
+    });
+
+    it("does redact a message with too many mentions", async function() {
+        await client.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir rooms add ${room}` });
+        await getFirstReaction(client, this.mjolnir.managementRoomId, '✅', async () => {
+                return await client.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: "!mjolnir enable MentionSpam" });
+        });
+        // Also covers HTML mentions
+        const mentionUsers = Array.from({length: DEFAULT_MAX_MENTIONS}, (_, i) => `@user${i}:example.org`);
+        const messageWithTextMentions = await client.sendText(room, 'Hello world ' + mentionUsers.join(' '));
+        const messageWithMMentions = await client.sendMessage(room, {
+            content: {
+                msgtype: 'm.text',
+                body: 'Hello world',
+                ['m.mentions']: {
+                    user_ids: mentionUsers
+                }
+            }
+        });
+
+        await delay(500);
+        const fetchedTextEvent = await client.getEvent(room, messageWithTextMentions);
+        assert.equal(Object.keys(fetchedTextEvent.content).length, 0, "This event should have been redacted");
+        const fetchedMentionsEvent = await client.getEvent(room, messageWithMMentions);
+        assert.equal(Object.keys(fetchedMentionsEvent.content).length, 0, "This event should have been redacted");
+    });
+});

--- a/test/integration/mentionSpamProtectionTest.ts
+++ b/test/integration/mentionSpamProtectionTest.ts
@@ -70,7 +70,7 @@ describe("Test: Mention spam protection", function () {
                 return await client.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: "!mjolnir enable MentionSpam" });
         });
         // Also covers HTML mentions
-        const mentionUsers = Array.from({length: DEFAULT_MAX_MENTIONS}, (_, i) => `@user${i}:example.org`);
+        const mentionUsers = Array.from({length: DEFAULT_MAX_MENTIONS+1}, (_, i) => `@user${i}:example.org`);
         const messageWithTextMentions = await client.sendText(room, 'Hello world ' + mentionUsers.join(' '));
         const messageWithMMentions = await client.sendMessage(room, {
             msgtype: 'm.text',

--- a/test/integration/mentionSpamProtectionTest.ts
+++ b/test/integration/mentionSpamProtectionTest.ts
@@ -71,7 +71,7 @@ describe("Test: Mention spam protection", function () {
         });
         // Also covers HTML mentions
         const mentionUsers = Array.from({length: DEFAULT_MAX_MENTIONS+1}, (_, i) => `@user${i}:example.org`);
-        const messageWithTextMentions = await client.sendText(room, 'Hello world ' + mentionUsers.join(' '));
+        const messageWithTextMentions = await client.sendText(room, mentionUsers.join(' '));
         const messageWithMMentions = await client.sendMessage(room, {
             msgtype: 'm.text',
             body: 'Hello world',

--- a/test/integration/mentionSpamProtectionTest.ts
+++ b/test/integration/mentionSpamProtectionTest.ts
@@ -35,7 +35,7 @@ describe("Test: Mention spam protection", function () {
 
         await delay(500);
         const fetchedEvent = await client.getEvent(room, testMessage);
-        assert.equal(Object.keys(fetchedEvent.content).length, 3, "This event should not have been redacted");
+        assert.equal(Object.keys(fetchedEvent.content).length, 2, "This event should not have been redacted");
     });
 
     it("does not redact a message with some mentions", async function() {
@@ -46,22 +46,20 @@ describe("Test: Mention spam protection", function () {
         // Also covers HTML mentions
         const messageWithTextMentions = await client.sendText(room, 'Hello world @foo:bar @beep:boop @test:here');
         const messageWithMMentions = await client.sendMessage(room, {
-            content: {
-                msgtype: 'm.text',
-                body: 'Hello world',
-                ['m.mentions']: {
-                    user_ids: [
-                        "@foo:bar",
-                        "@beep:boop",
-                        "@test:here"
-                    ]
-                }
+            msgtype: 'm.text',
+            body: 'Hello world',
+            ['m.mentions']: {
+                user_ids: [
+                    "@foo:bar",
+                    "@beep:boop",
+                    "@test:here"
+                ]
             }
         });
 
         await delay(500);
         const fetchedTextEvent = await client.getEvent(room, messageWithTextMentions);
-        assert.equal(Object.keys(fetchedTextEvent.content).length, 3, "This event should not have been redacted");
+        assert.equal(Object.keys(fetchedTextEvent.content).length, 2, "This event should not have been redacted");
         const fetchedMentionsEvent = await client.getEvent(room, messageWithMMentions);
         assert.equal(Object.keys(fetchedMentionsEvent.content).length, 3, "This event should not have been redacted");
     });
@@ -75,12 +73,10 @@ describe("Test: Mention spam protection", function () {
         const mentionUsers = Array.from({length: DEFAULT_MAX_MENTIONS}, (_, i) => `@user${i}:example.org`);
         const messageWithTextMentions = await client.sendText(room, 'Hello world ' + mentionUsers.join(' '));
         const messageWithMMentions = await client.sendMessage(room, {
-            content: {
-                msgtype: 'm.text',
-                body: 'Hello world',
-                ['m.mentions']: {
-                    user_ids: mentionUsers
-                }
+            msgtype: 'm.text',
+            body: 'Hello world',
+            ['m.mentions']: {
+                user_ids: mentionUsers
             }
         });
 

--- a/test/integration/mentionSpamProtectionTest.ts
+++ b/test/integration/mentionSpamProtectionTest.ts
@@ -1,6 +1,6 @@
 import {newTestUser} from "./clientHelper";
 
-import {MatrixClient} from "matrix-bot-sdk";
+import {MatrixClient} from "@vector-im/matrix-bot-sdk";
 import {getFirstReaction} from "./commands/commandUtils";
 import {strict as assert} from "assert";
 import { DEFAULT_MAX_MENTIONS } from "../../src/protections/MentionSpam";


### PR DESCRIPTION
Fixes #309 #211 

This protection checks whether a message contains a large number of mentions and redacts the message. It currently checks the mentions array, then the body and finally the formatted body. I've chosen 10 as a sensible max number of mentions before the message may be considered spam, although this is configurable via a setting.