### PR TITLE
Remove notes from the default config.yaml that suggest mjolnir's wordlist feature supports regex, it does not.

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -173,11 +173,6 @@ protections:
     # A list of case-insensitive keywords that the WordList protection will watch for from new users.
     #
     # WordList will ban users who use these words when first joining a room, so take caution when selecting them.
-    #
-    # For advanced usage, regex can also be used, see the following links for more information;
-    #  - https://www.digitalocean.com/community/tutorials/an-introduction-to-regular-expressions
-    #  - https://regexr.com/
-    #  - https://regexone.com/
     words:
       - "LoReM"
       - "IpSuM"


### PR DESCRIPTION
A small fix to the comments inside the default config.yaml. They incorrectly state that you can use regex with mjolnir's wordlist feature.

Mjolnir's wordlist feature does not support regex, these comments are misleading. fixes #539