### PR TITLE
Add RegExps support for Mjolnir's WordList protection

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -174,6 +174,14 @@ protections:
   # Configuration for the wordlist plugin, which can ban users based if they say certain
   # blocked words shortly after joining.
   wordlist:
+    # For advanced usage, regex can also be enabled. If left disabled Mjolnir will interpret words literally.
+    #
+    # See the following links for more information;
+    #  - https://www.digitalocean.com/community/tutorials/an-introduction-to-regular-expressions
+    #  - https://regexr.com/
+    #  - https://regexone.com/
+    enableRegExps: false
+
     # A list of case-insensitive keywords that the WordList protection will watch for from new users.
     #
     # WordList will ban users who use these words when first joining a room, so take caution when selecting them.

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -176,10 +176,11 @@ protections:
   wordlist:
     # For advanced usage, regex can also be enabled. If left disabled Mjolnir will interpret words literally.
     #
+    # For example, if enabled this 'word' would match all t.me links: (https?:\/\/)?t\.me\/(\+)?[a-zA-Z0-9_-]+
+    #
     # See the following links for more information;
     #  - https://www.digitalocean.com/community/tutorials/an-introduction-to-regular-expressions
     #  - https://regexr.com/
-    #  - https://regexone.com/
     enableRegExps: false
 
     # A list of case-insensitive keywords that the WordList protection will watch for from new users.

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,7 +127,7 @@ export interface IConfig {
     };
     protections: {
         wordlist: {
-            enableRegexps: boolean;
+            enableRegExps: boolean;
             words: string[];
             minutesBeforeTrusting: number;
         };
@@ -247,7 +247,7 @@ const defaultConfig: IConfig = {
     },
     protections: {
         wordlist: {
-            enableRegexps: false,
+            enableRegExps: false,
             words: [],
             minutesBeforeTrusting: 20,
         },

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,6 +127,7 @@ export interface IConfig {
     };
     protections: {
         wordlist: {
+            enableRegexps: boolean;
             words: string[];
             minutesBeforeTrusting: number;
         };
@@ -246,6 +247,7 @@ const defaultConfig: IConfig = {
     },
     protections: {
         wordlist: {
+            enableRegexps: false,
             words: [],
             minutesBeforeTrusting: 20,
         },

--- a/src/protections/WordList.ts
+++ b/src/protections/WordList.ts
@@ -88,7 +88,7 @@ export class WordList extends Protection {
                 }
             }
             if (!this.badWords) {
-                const enableRegexps = mjolnir.config.protections.wordlist.enableRegexps || false;
+                const enableRegExps = mjolnir.config.protections.wordlist.enableRegExps || false;
                 const words = mjolnir.config.protections.wordlist.words.filter((word) => word.length !== 0);
 
                 if (words.length === 0) {
@@ -101,7 +101,7 @@ export class WordList extends Protection {
                     return;
                 }
 
-                if (enableRegexps) {
+                if (enableRegExps) {
                     this.badWords = new RegExp(words.join("|"), "i");
                 } else {
                     // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping


### PR DESCRIPTION
Well it did not take long for the spammers to side-step my word-list...

So here's a patch that actually allows you to enable regular expression support with Mjolnir's WordList protection! Making it substantially more powerful. :sunglasses: 

I've tested this patch out and it appears to work flawlessly. Happy to revise it and re-test if needed.

---

Fixes https://github.com/matrix-org/mjolnir/issues/547