### PR TITLE
Notify moderation room when users in protected rooms mention the bot (configurable)

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -65,6 +65,10 @@ recordIgnoredInvites: false
 # (see verboseLogging to adjust this a bit.)
 managementRoom: "#moderators:example.org"
 
+# Forward any messages mentioning the bot user to the mangement room. Repeated mentions within
+# a 10 minute period are ignored.
+forwardMentionsToManagementRoom: false
+
 # Whether Mjolnir should log a lot more messages in the room,
 # mainly involves "all-OK" messages, and debugging messages for when mjolnir checks bans in a room.
 verboseLogging: true

--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 The Matrix.org Foundation C.I.C.
+Copyright 2019-2024 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,6 +90,7 @@ export interface IConfig {
     acceptInvitesFromSpace: string;
     recordIgnoredInvites: boolean;
     managementRoom: string;
+    forwardMentionsToManagementRoom: boolean;
     verboseLogging: boolean;
     logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR";
     syncOnStartup: boolean;
@@ -209,6 +210,7 @@ const defaultConfig: IConfig = {
     autojoinOnlyIfManager: true,
     recordIgnoredInvites: false,
     managementRoom: "!noop:example.org",
+    forwardMentionsToManagementRoom: false,
     verboseLogging: false,
     logLevel: "INFO",
     syncOnStartup: true,

--- a/test/integration/forwardedMentionsTest.ts
+++ b/test/integration/forwardedMentionsTest.ts
@@ -1,7 +1,24 @@
+/*
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { MatrixClient, UserID } from "@vector-im/matrix-bot-sdk";
 import { Mjolnir } from "../../src/Mjolnir";
 import { newTestUser, noticeListener } from "./clientHelper";
 import { strict as assert } from "assert";
+import expect from "expect";
 
 describe("Test: config.forwardMentionsToManagementRoom behaves correctly.", function () {
     let moderator: MatrixClient;
@@ -55,5 +72,46 @@ describe("Test: config.forwardMentionsToManagementRoom behaves correctly.", func
             `Bot mentioned ${protectedRoom} by ${mentioningUserId} in https://matrix.to/#/${protectedRoom}/${mentionEventId}?via=${domain}`,
             "Forwarded mention format mismatch",
         );
+    });
+
+    it("only forwards the first mention from a user.", async function () {
+        const mjolnir: Mjolnir = this.mjolnir!;
+        const botUserId = await mjolnir.client.getUserId();
+        mjolnir.config.forwardMentionsToManagementRoom = true;
+
+        const mentioninguser = await newTestUser(this.config.homeserverUrl, { name: { contains: "mentioninguser" } });
+        await moderator.joinRoom(mjolnir.managementRoomId);
+        const protectedRoom = await moderator.createRoom({ preset: "public_chat" });
+        await mjolnir.client.joinRoom(protectedRoom);
+        await mentioninguser.joinRoom(protectedRoom);
+        await mjolnir.protectedRoomsTracker.addProtectedRoom(protectedRoom);
+
+        await moderator.start();
+        let mentionCount = 0;
+        moderator.on(
+            "room.message",
+            noticeListener(this.mjolnir.managementRoomId, (event) => {
+                if (event.content.body.includes(`Bot mentioned`)) {
+                    mentionCount++;
+                }
+            }),
+        );
+
+        function delay(ms: number) {
+            return new Promise((resolve) => setTimeout(resolve, ms));
+        }
+
+        for (let index = 0; index < 5; index++) {
+            await mentioninguser.sendMessage(protectedRoom, {
+                msgtype: "m.text",
+                body: `Moderator: Testing this ${index}`,
+                ["m.mentions"]: {
+                    user_ids: [botUserId],
+                },
+            });
+            await delay(2000);
+        }
+
+        expect(mentionCount).toBe(1);
     });
 });

--- a/test/integration/forwardedMentionsTest.ts
+++ b/test/integration/forwardedMentionsTest.ts
@@ -1,0 +1,59 @@
+import { MatrixClient, UserID } from "@vector-im/matrix-bot-sdk";
+import { Mjolnir } from "../../src/Mjolnir";
+import { newTestUser, noticeListener } from "./clientHelper";
+import { strict as assert } from "assert";
+
+describe("Test: config.forwardMentionsToManagementRoom behaves correctly.", function () {
+    let moderator: MatrixClient;
+    this.beforeEach(async function () {
+        moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
+        await moderator.start();
+    });
+
+    this.afterEach(async function () {
+        moderator.stop();
+    });
+
+    it("correctly forwards a mention.", async function () {
+        const mjolnir: Mjolnir = this.mjolnir!;
+        const botUserId = await mjolnir.client.getUserId();
+        mjolnir.config.forwardMentionsToManagementRoom = true;
+
+        const mentioninguser = await newTestUser(this.config.homeserverUrl, { name: { contains: "mentioninguser" } });
+        const mentioningUserId = await mentioninguser.getUserId();
+        await moderator.joinRoom(mjolnir.managementRoomId);
+        const protectedRoom = await moderator.createRoom({ preset: "public_chat" });
+        await mjolnir.client.joinRoom(protectedRoom);
+        await mentioninguser.joinRoom(protectedRoom);
+        await mjolnir.protectedRoomsTracker.addProtectedRoom(protectedRoom);
+
+        await moderator.start();
+        const noticeBody = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error("Timed out waiting for notice")), 8000);
+            moderator.on(
+                "room.message",
+                noticeListener(this.mjolnir.managementRoomId, (event) => {
+                    if (event.content.body.includes(`Bot mentioned`)) {
+                        clearTimeout(timeout);
+                        resolve(event.content.body);
+                    }
+                }),
+            );
+        });
+
+        const mentionEventId = await mentioninguser.sendMessage(protectedRoom, {
+            msgtype: "m.text",
+            body: "Moderator: Testing this",
+            ["m.mentions"]: {
+                user_ids: [botUserId],
+            },
+        });
+        const domain = new UserID(mentioningUserId).domain;
+
+        assert.equal(
+            await noticeBody,
+            `Bot mentioned ${protectedRoom} by ${mentioningUserId} in https://matrix.to/#/${protectedRoom}/${mentionEventId}?via=${domain}`,
+            "Forwarded mention format mismatch",
+        );
+    });
+});

--- a/test/integration/forwardedMentionsTest.ts
+++ b/test/integration/forwardedMentionsTest.ts
@@ -87,12 +87,12 @@ describe("Test: config.forwardMentionsToManagementRoom behaves correctly.", func
         await mjolnir.protectedRoomsTracker.addProtectedRoom(protectedRoom);
 
         await moderator.start();
-        let mentionCount = 0;
+        let mentions = new Set();
         moderator.on(
             "room.message",
             noticeListener(this.mjolnir.managementRoomId, (event) => {
                 if (event.content.body.includes(`Bot mentioned`)) {
-                    mentionCount++;
+                    mentions.add(event.event_id);
                 }
             }),
         );
@@ -112,6 +112,6 @@ describe("Test: config.forwardMentionsToManagementRoom behaves correctly.", func
             await delay(2000);
         }
 
-        expect(mentionCount).toBe(1);
+        expect(mentions.size).toBe(1);
     });
 });

--- a/test/integration/protectedRoomsConfigTest.ts
+++ b/test/integration/protectedRoomsConfigTest.ts
@@ -4,10 +4,9 @@ import { MatrixSendClient } from "../../src/MatrixEmitter";
 import { Mjolnir } from "../../src/Mjolnir";
 import PolicyList from "../../src/models/PolicyList";
 import { newTestUser } from "./clientHelper";
-import { createBanList, getFirstReaction } from "./commands/commandUtils";
+import { createBanList } from "./commands/commandUtils";
 
 async function createPolicyList(client: MatrixClient): Promise<PolicyList> {
-    const serverName = new UserID(await client.getUserId()).domain;
     const policyListId = await client.createRoom({ preset: "public_chat" });
     return new PolicyList(policyListId, Permalinks.forRoom(policyListId), client);
 }

--- a/test/integration/standardConsequenceTest.ts
+++ b/test/integration/standardConsequenceTest.ts
@@ -1,9 +1,6 @@
-import { strict as assert } from "assert";
-
 import { Mjolnir } from "../../src/Mjolnir";
 import { Protection } from "../../src/protections/IProtection";
-import { newTestUser, noticeListener } from "./clientHelper";
-import { matrixClient, mjolnir } from "./mjolnirSetupUtils";
+import { newTestUser } from "./clientHelper";
 import { ConsequenceBan, ConsequenceRedact } from "../../src/protections/consequence";
 
 describe("Test: standard consequences", function () {


### PR DESCRIPTION
Fixes https://github.com/matrix-org/mjolnir/issues/89

This works by checking to see if the bot has been mentioned in any of the protected rooms when a message comes in, and then will ignore any future mentions for the next 8 minutes (giving administrators a chance to deal with the offense, and to reduce spam). 

This is off-by-default, as it's enough of a behaviour change that I think administrators should opt into this explicitly.