### PR TITLE
Skip NSFW classification if treshold is 0.0

### DIFF
--- a/src/protections/NsfwProtection.ts
+++ b/src/protections/NsfwProtection.ts
@@ -58,7 +58,7 @@ export class NsfwProtection extends Protection {
         const maybeAlias = await mjolnir.client.getPublishedAlias(roomId);
         const room = maybeAlias ? maybeAlias : roomId;
 
-        // Skip classification is sensitivity is 0, as it's a waste of resources
+        // Skip classification if sensitivity is 0, as it's a waste of resources
         // We are using 0.0001 as a threshold to avoid floating point errors
         if (mjolnir.config.nsfwSensitivity <= 0.0001) {
             await this.redactEvent(mjolnir, roomId, event, room);

--- a/src/protections/NsfwProtection.ts
+++ b/src/protections/NsfwProtection.ts
@@ -74,33 +74,37 @@ export class NsfwProtection extends Protection {
             for (const prediction of predictions) {
                 if (["Hentai", "Porn"].includes(prediction["className"])) {
                     if (prediction["probability"] > mjolnir.config.nsfwSensitivity) {
-                        try {
-                            await mjolnir.client.redactEvent(roomId, event["event_id"]);
-                        } catch (err) {
-                            await mjolnir.managementRoomOutput.logMessage(
-                                LogLevel.ERROR,
-                                "NSFWProtection",
-                                `There was an error redacting ${event["event_id"]} in ${room}: ${err}`,
-                            );
-                        }
-                        let eventId = event["event_id"];
-                        let body = `Redacted an image in ${room} ${eventId}`;
-                        let formatted_body = `<details>
-                                                <summary>Redacted an image in ${room}</summary>
-                                                <pre>${eventId}</pre>  <pre>${room}</pre>
-                                                </details>`;
-                        const msg = {
-                            msgtype: "m.notice",
-                            body: body,
-                            format: "org.matrix.custom.html",
-                            formatted_body: formatted_body,
-                        };
-                        await mjolnir.client.sendMessage(mjolnir.managementRoomId, msg);
+                        await this.redactEvent(mjolnir, roomId, mxc, event, room);
                         break;
                     }
                 }
             }
             decodedImage.dispose();
         }
+    }
+
+    private async redactEvent(mjolnir: Mjolnir, roomId, string, event: any, room: string): Promise<any> {
+        try {
+            await mjolnir.client.redactEvent(roomId, event["event_id"]);
+        } catch (err) {
+            await mjolnir.managementRoomOutput.logMessage(
+                LogLevel.ERROR,
+                "NSFWProtection",
+                `There was an error redacting ${event["event_id"]} in ${room}: ${err}`,
+            );
+        }
+        let eventId = event["event_id"];
+        let body = `Redacted an image in ${room} ${eventId}`;
+        let formatted_body = `<details>
+                              <summary>Redacted an image in ${room}</summary>
+                              <pre>${eventId}</pre>  <pre>${room}</pre>
+                              </details>`;
+        const msg = {
+            msgtype: "m.notice",
+            body: body,
+            format: "org.matrix.custom.html",
+            formatted_body: formatted_body,
+        };
+        await mjolnir.client.sendMessage(mjolnir.managementRoomId, msg);
     }
 }


### PR DESCRIPTION
This PR adds the ability to skip NSFW processing if the sensitivity is set to 0.0.
This saves resources, and makes redactions happen faster, allowing it to be used as a generic "disallow images" protection.

I wonder if a setting to opt out of this behavior should be included, even though one could set the sensitivity to 0.0002 to opt out?