### PR TITLE
Support scanning stickers for NSFW content, and don't error so loudly when a MXC is missing

### DIFF
--- a/src/protections/NsfwProtection.ts
+++ b/src/protections/NsfwProtection.ts
@@ -45,7 +45,7 @@ export class NsfwProtection extends Protection {
     }
 
     public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any> {
-        if (event.type !== "m.room.message" || event.type !== "m.sticker") {
+        if (event.type !== "m.room.message" && event.type !== "m.sticker") {
             return;
         }
 

--- a/src/protections/NsfwProtection.ts
+++ b/src/protections/NsfwProtection.ts
@@ -45,7 +45,9 @@ export class NsfwProtection extends Protection {
     }
 
     public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any> {
-        if (event["type"] === "m.room.message") {
+        if (event.type !== "m.room.message" || event.type !== "m.sticker") {
+            return;
+        }
 
         const content = JSON.stringify(event.content);
         const mxcs = content.match(/(mxc:\/\/[^\s'"]+)/gim);

--- a/src/protections/NsfwProtection.ts
+++ b/src/protections/NsfwProtection.ts
@@ -46,70 +46,59 @@ export class NsfwProtection extends Protection {
 
     public async handleEvent(mjolnir: Mjolnir, roomId: string, event: any): Promise<any> {
         if (event["type"] === "m.room.message") {
-            let content = JSON.stringify(event["content"]);
-            if (!content.toLowerCase().includes("mxc")) {
-                return;
+
+        const content = JSON.stringify(event.content);
+        const mxcs = content.match(/(mxc:\/\/[^\s'"]+)/gim);
+        if (!mxcs) {
+            return;
+        }
+        // try and grab a human-readable alias for more helpful management room output
+        const maybeAlias = await mjolnir.client.getPublishedAlias(roomId);
+        const room = maybeAlias ? maybeAlias : roomId;
+
+        for (const mxc of mxcs) {
+            const image = await mjolnir.client.downloadContent(mxc);
+
+            let decodedImage;
+            try {
+                decodedImage = await node.decodeImage(image.data, 3);
+            } catch (e) {
+                LogService.error("NsfwProtection", `There was an error processing an image: ${e}`);
+                continue;
             }
-            // try and grab a human-readable alias for more helpful management room output
-            const maybeAlias = await mjolnir.client.getPublishedAlias(roomId);
-            const room = maybeAlias ? maybeAlias : roomId;
 
-            const mxcs = content.match(/(mxc?:\/\/[^\s'"]+)/gim);
-            if (!mxcs) {
-                //something's gone wrong with the regex
-                await mjolnir.managementRoomOutput.logMessage(
-                    LogLevel.ERROR,
-                    "NSFWProtection",
-                    `Unable to find any mxcs in  ${event["event_id"]} in ${room}`,
-                );
-                return;
-            }
+            const predictions = await this.model.classify(decodedImage);
 
-            // @ts-ignore - see null check immediately above
-            for (const mxc of mxcs) {
-                const image = await mjolnir.client.downloadContent(mxc);
-
-                let decodedImage;
-                try {
-                    decodedImage = await node.decodeImage(image.data, 3);
-                } catch (e) {
-                    LogService.error("NsfwProtection", `There was an error processing an image: ${e}`);
-                    continue;
-                }
-
-                const predictions = await this.model.classify(decodedImage);
-
-                for (const prediction of predictions) {
-                    if (["Hentai", "Porn"].includes(prediction["className"])) {
-                        if (prediction["probability"] > mjolnir.config.nsfwSensitivity) {
-                            try {
-                                await mjolnir.client.redactEvent(roomId, event["event_id"]);
-                            } catch (err) {
-                                await mjolnir.managementRoomOutput.logMessage(
-                                    LogLevel.ERROR,
-                                    "NSFWProtection",
-                                    `There was an error redacting ${event["event_id"]} in ${room}: ${err}`,
-                                );
-                            }
-                            let eventId = event["event_id"];
-                            let body = `Redacted an image in ${room} ${eventId}`;
-                            let formatted_body = `<details>
-                                                  <summary>Redacted an image in ${room}</summary>
-                                                  <pre>${eventId}</pre>  <pre>${room}</pre>
-                                                  </details>`;
-                            const msg = {
-                                msgtype: "m.notice",
-                                body: body,
-                                format: "org.matrix.custom.html",
-                                formatted_body: formatted_body,
-                            };
-                            await mjolnir.client.sendMessage(mjolnir.managementRoomId, msg);
-                            break;
+            for (const prediction of predictions) {
+                if (["Hentai", "Porn"].includes(prediction["className"])) {
+                    if (prediction["probability"] > mjolnir.config.nsfwSensitivity) {
+                        try {
+                            await mjolnir.client.redactEvent(roomId, event["event_id"]);
+                        } catch (err) {
+                            await mjolnir.managementRoomOutput.logMessage(
+                                LogLevel.ERROR,
+                                "NSFWProtection",
+                                `There was an error redacting ${event["event_id"]} in ${room}: ${err}`,
+                            );
                         }
+                        let eventId = event["event_id"];
+                        let body = `Redacted an image in ${room} ${eventId}`;
+                        let formatted_body = `<details>
+                                                <summary>Redacted an image in ${room}</summary>
+                                                <pre>${eventId}</pre>  <pre>${room}</pre>
+                                                </details>`;
+                        const msg = {
+                            msgtype: "m.notice",
+                            body: body,
+                            format: "org.matrix.custom.html",
+                            formatted_body: formatted_body,
+                        };
+                        await mjolnir.client.sendMessage(mjolnir.managementRoomId, msg);
+                        break;
                     }
                 }
-                decodedImage.dispose();
             }
+            decodedImage.dispose();
         }
     }
 }


### PR DESCRIPTION
For the size of a standard matrix event, it's not worth doing two matches for `mxc` here.