### PR TITLE
Support Arm architectures for Docker containers

### DIFF
--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   DOCKER_NAMESPACE: matrixdotorg
-  PLATFORMS: linux/amd64
+  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
   # Only push if this is main, otherwise we just want to build
   PUSH: ${{ github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   DOCKER_NAMESPACE: matrixdotorg
-  PLATFORMS: linux/amd64
+  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
 
 jobs:
   docker-release:


### PR DESCRIPTION
Add `linux/arm64`, `linux/arm/v7` and `linux/arm/v6` architectures support for Docker containers.

Which will solve #74.