### PR TITLE
Use admin redaction endpoint if possible

### DIFF
--- a/src/commands/RedactCommand.ts
+++ b/src/commands/RedactCommand.ts
@@ -73,7 +73,8 @@ export async function execRedactCommand(roomId: string, event: any, mjolnir: Mjo
     }
 
     const targetRoomIds = targetRoom ? [targetRoom] : mjolnir.protectedRoomsTracker.getProtectedRooms();
-    await redactUserMessagesIn(mjolnir.client, mjolnir.managementRoomOutput, userId, targetRoomIds, false, limit);
+    const isAdmin = await mjolnir.isSynapseAdmin();
+    await redactUserMessagesIn(mjolnir.client, mjolnir.managementRoomOutput, userId, targetRoomIds, isAdmin, limit);
     if (quarantine) {
         const mxcs = await mjolnir.protectedRoomsTracker.getMediaIdsForUserIdInRooms(userId, targetRoomIds);
         for (const mxc of mxcs) {

--- a/src/queues/EventRedactionQueue.ts
+++ b/src/queues/EventRedactionQueue.ts
@@ -53,7 +53,7 @@ export class RedactUserInRoom implements QueuedRedaction {
             "Mjolnir",
             `Redacting events from ${this.userId} in room ${this.roomId}.`,
         );
-        await redactUserMessagesIn(client, managementRoom, this.userId, [this.roomId], false);
+        await redactUserMessagesIn(client, managementRoom, this.userId, [this.roomId], this.isAdmin);
     }
 
     public redactionEqual(redaction: QueuedRedaction): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,7 +71,7 @@ async function adminRedactUserMessagesIn(
     targetRooms: string[],
     limit = 1000,
 ) {
-    const body = { limit: limit, rooms: targetRooms };
+    const body = { limit: limit, rooms: targetRooms, use_admin: true };
     const redactEndpoint = `/_synapse/admin/v1/user/${userId}/redact`;
     const response = await client.doRequest("POST", redactEndpoint, null, body);
     const redactID = response["redact_id"];


### PR DESCRIPTION
https://github.com/element-hq/synapse/pull/18671 now allows us to use the admin user to issue redactions if desired - use this when we have admin priviledges to issue redactions in rooms mjolnir protects